### PR TITLE
[#34] Feat : rest docs 설정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,8 @@ out/
 !**/src/main/**/out/
 !**/src/test/**/out/
 /log
+# Restdocs html -> 자동 생성
+**/src/main/**/docs/
 
 ### NetBeans ###
 /nbproject/private/

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id 'org.springframework.boot' version '3.0.5'
     id 'io.spring.dependency-management' version '1.1.0'
     id 'jacoco'
-    id 'org.asciidoctor.jvm.convert' version 'latest.release'
+    id 'org.asciidoctor.jvm.convert' version '3.3.2'
 }
 
 
@@ -12,6 +12,7 @@ version = '1.0.0'
 sourceCompatibility = '17'
 
 configurations {
+    asciidoctorExtensions
     compileOnly {
         extendsFrom annotationProcessor
     }
@@ -36,7 +37,7 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
-    testImplementation 'org.springframework.restdocs:spring-restdocs-asciidoctor'
+    asciidoctorExtensions 'org.springframework.restdocs:spring-restdocs-asciidoctor'
 }
 
 /*jacoco 설정*/
@@ -76,8 +77,14 @@ ext {
 }
 
 asciidoctor {
+    attributes 'snippets' : snippetsDir
+    configurations 'asciidoctorExtensions'
+    forkOptions {
+        jvmArgs('--add-opens', 'java.base/sun.nio.ch=ALL-UNNAMED','--add-opens','java.base/java.io=ALL-UNNAMED')
+    }
     dependsOn test
     inputs.dir snippetsDir
+    baseDirFollowsSourceFile()
 }
 
 asciidoctor.doFirst {
@@ -86,9 +93,8 @@ asciidoctor.doFirst {
 
 bootJar {
     dependsOn asciidoctor
-    copy {
-        from "${asciidoctor.outputDir}"
-        into 'BOOT-INF/classes/static/docs'
+    from("${asciidoctor.outputDir}/html5") {
+        into 'static/docs'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'org.springframework.boot' version '3.0.5'
     id 'io.spring.dependency-management' version '1.1.0'
     id 'jacoco'
+    id 'org.asciidoctor.jvm.convert' version 'latest.release'
 }
 
 
@@ -34,13 +35,11 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
+    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+    testImplementation 'org.springframework.restdocs:spring-restdocs-asciidoctor'
 }
 
-tasks.named('test') {
-    useJUnitPlatform()
-    finalizedBy 'jacocoTestReport'
-}
-
+/*jacoco 설정*/
 jacocoTestReport {
     dependsOn test
     finalizedBy 'jacocoTestCoverageVerification'
@@ -66,3 +65,41 @@ jacocoTestCoverageVerification {
     }
 
 }
+
+tasks.named('test') {
+    useJUnitPlatform()
+    finalizedBy 'jacocoTestReport'
+}
+
+ext {
+    snippetsDir = file('build/generated-snippets')
+}
+
+asciidoctor {
+    dependsOn test
+    inputs.dir snippetsDir
+}
+
+asciidoctor.doFirst {
+    delete file('src/main/resources/static/docs')
+}
+
+bootJar {
+    dependsOn asciidoctor
+    copy {
+        from "${asciidoctor.outputDir}"
+        into 'BOOT-INF/classes/static/docs'
+    }
+}
+
+task copyDocument(type: Copy) {
+    dependsOn asciidoctor
+    from file("build/docs/asciidoc")
+    into file("src/main/resources/static/docs")
+}
+
+build {
+    dependsOn copyDocument
+}
+
+

--- a/src/docs/asciidoc/Diray-API.adoc
+++ b/src/docs/asciidoc/Diray-API.adoc
@@ -1,0 +1,105 @@
+[[Diray-API]]
+== 회고 API
+
+=== 공통
+
+==== 모든 요청은 *Authorization* 헤더가 필요합니다.
+
+include::{snippets}/member-update/request-headers.adoc[]
+
+---
+
+=== 회고 등록
+
+==== Request
+include::{snippets}/diary-create/request-fields.adoc[]
+
+===== Request HTTP Example
+
+include::{snippets}/diary-create/http-request.adoc[]
+
+==== Response
+
+include::{snippets}/diary-create/response-fields.adoc[]
+
+===== Response HTTP Example
+
+include::{snippets}/diary-create/http-response.adoc[]
+
+=== 회고 조회
+
+==== Request
+
+===== Request HTTP Example
+
+include::{snippets}/all-diary-read/http-request.adoc[]
+
+==== Response
+
+include::{snippets}/all-diary-read/response-fields.adoc[]
+
+===== Response HTTP Example
+
+include::{snippets}/all-diary-read/http-response.adoc[]
+
+=== 월별 회고 조회
+
+==== Request
+
+include::{snippets}/monthly-diary-read/query-parameters.adoc[]
+
+===== Request HTTP Example
+
+include::{snippets}/monthly-diary-read/http-request.adoc[]
+
+==== Response
+
+include::{snippets}/monthly-diary-read/response-fields.adoc[]
+
+===== Response HTTP Example
+
+include::{snippets}/monthly-diary-read/http-response.adoc[]
+
+=== 회고 수정
+
+*endpoint* +
+_/diaries/{diaryId}_
+
+==== Request
+
+include::{snippets}/diary-update/path-parameters.adoc[]
+
+include::{snippets}/diary-update/request-fields.adoc[]
+
+===== Request HTTP Example
+
+include::{snippets}/diary-update/http-request.adoc[]
+
+==== Response
+
+include::{snippets}/diary-update/response-fields.adoc[]
+
+===== Response HTTP Example
+
+include::{snippets}/diary-update/http-response.adoc[]
+
+=== 회고 삭제
+
+*endpoint* +
+_/diaries/{diaryId}_
+
+==== Request
+
+include::{snippets}/diary-delete/path-parameters.adoc[]
+
+===== Request HTTP Example
+
+include::{snippets}/diary-delete/http-request.adoc[]
+
+==== Response
+
+include::{snippets}/diary-delete/response-fields.adoc[]
+
+===== Response HTTP Example
+
+include::{snippets}/diary-delete/http-response.adoc[]

--- a/src/docs/asciidoc/Habit-API.adoc
+++ b/src/docs/asciidoc/Habit-API.adoc
@@ -1,0 +1,125 @@
+[[Habit-API]]
+== 습관 API
+
+=== 공통
+
+==== 모든 요청은 *Authorization* 헤더가 필요합니다.
+
+include::{snippets}/member-update/request-headers.adoc[]
+
+---
+
+=== 습관 등록
+
+==== Request
+
+include::{snippets}/habit-created/request-fields.adoc[]
+
+===== Request HTTP Example
+
+include::{snippets}/habit-created/http-request.adoc[]
+
+==== Response
+
+include::{snippets}/habit-created/response-fields.adoc[]
+
+===== Response HTTP Example
+
+include::{snippets}/habit-created/http-response.adoc[]
+
+=== 습관 리스트 조회
+
+==== Request
+
+include::{snippets}/habit-read/request-fields.adoc[]
+
+===== Request HTTP Example
+
+include::{snippets}/habit-read/http-request.adoc[]
+
+==== Response
+
+include::{snippets}/habit-read/response-fields.adoc[]
+
+===== Response HTTP Example
+
+include::{snippets}/habit-read/http-response.adoc[]
+
+=== 월별 습관 리스트 조회
+
+==== Request
+
+include::{snippets}/monthly-habit-read/query-parameters.adoc[]
+
+===== Request HTTP Example
+
+include::{snippets}/monthly-habit-read/http-request.adoc[]
+
+==== Response
+
+include::{snippets}/monthly-habit-read/response-fields.adoc[]
+
+===== Response HTTP Example
+
+include::{snippets}/monthly-habit-read/http-response.adoc[]
+
+=== 습관 삭제
+*endpoint* +
+_/habit/{habitId}_
+
+==== Request
+
+include::{snippets}/habit-delete/path-parameters.adoc[]
+
+===== Request HTTP Example
+
+include::{snippets}/habit-delete/http-request.adoc[]
+
+==== Response
+
+===== Response HTTP Example
+
+include::{snippets}/habit-delete/http-response.adoc[]
+
+
+=== 습관 체크 등록
+
+*endpoint* +
+_/habit/{habitId}/check_
+
+==== Request
+
+include::{snippets}/habitCheck-create/path-parameters.adoc[]
+
+===== Request HTTP Example
+
+include::{snippets}/habitCheck-create/http-request.adoc[]
+
+==== Response
+
+include::{snippets}/habitCheck-create/response-fields.adoc[]
+
+===== Response HTTP Example
+
+include::{snippets}/habitCheck-create/http-response.adoc[]
+
+=== 습관 체크 취소
+
+*endpoint* +
+_/habit/{habitId}/check_
+
+==== Request
+
+include::{snippets}/habitCheck-delete/path-parameters.adoc[]
+
+===== Request HTTP Example
+
+include::{snippets}/habitCheck-delete/http-request.adoc[]
+
+==== Response
+
+include::{snippets}/habitCheck-delete/response-fields.adoc[]
+
+===== Response HTTP Example
+
+include::{snippets}/habitCheck-delete/http-response.adoc[]

--- a/src/docs/asciidoc/Member-API.adoc
+++ b/src/docs/asciidoc/Member-API.adoc
@@ -1,0 +1,75 @@
+[[Member-API]]
+== 유저 API
+
+=== 공통
+
+==== 로그인을 제외한 모든 요청은 *Authorization* 헤더가 필요합니다.
+
+include::{snippets}/member-update/request-headers.adoc[]
+
+---
+
+=== 내 정보 조회
+
+==== Request
+
+===== Request HTTP Example
+
+include::{snippets}/member-read/http-request.adoc[]
+
+==== Response
+
+include::{snippets}/member-read/response-fields.adoc[]
+
+===== Response HTTP Example
+
+include::{snippets}/member-read/http-response.adoc[]
+
+=== 유저 정보 수정
+
+==== Request
+
+include::{snippets}/member-update/request-fields.adoc[]
+
+===== Request HTTP Example
+
+include::{snippets}/member-update/http-request.adoc[]
+
+==== Response
+
+include::{snippets}/member-update/response-fields.adoc[]
+
+===== Response HTTP Example
+
+include::{snippets}/member-update/http-response.adoc[]
+
+=== 유저 삭제
+
+==== Request
+
+===== Request HTTP Example
+
+include::{snippets}/member-delete/http-request.adoc[]
+
+==== Response
+
+===== Response HTTP Example
+
+include::{snippets}/member-delete/http-response.adoc[]
+
+
+=== 에러
+
+==== Request
+
+===== Request HTTP Example
+
+include::{snippets}/duplicate-member/http-request.adoc[]
+
+==== Response
+
+include::{snippets}/duplicate-member/response-fields.adoc[]
+
+===== Response HTTP Example
+
+include::{snippets}/duplicate-member/http-response.adoc[]

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1,0 +1,16 @@
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 2
+:sectlinks:
+
+= habiters API 문서
+
+include::overview.adoc[]
+
+include::Member-API.adoc[]
+
+include::Habit-API.adoc[]
+
+include::Diray-API.adoc[]

--- a/src/docs/asciidoc/overview.adoc
+++ b/src/docs/asciidoc/overview.adoc
@@ -1,0 +1,27 @@
+[[overview]]
+== Overview
+
+[[overview-http-status-codes]]
+=== HTTP status codes
+
+|===
+| 상태 코드 | 설명
+
+| `200 OK`
+| 성공
+
+| `400 Bad Request`
+| 잘못된 요청
+
+| `401 Unauthorized`
+| 비인증 상태
+
+| `403 Forbidden`
+| 권한 거부
+
+| `404 Not Found`
+| 존재하지 않는 요청 리소스
+
+| `500 Internal Server Error`
+| 서버 에러
+|===

--- a/src/main/java/com/clover/habbittracker/global/dto/BaseResponse.java
+++ b/src/main/java/com/clover/habbittracker/global/dto/BaseResponse.java
@@ -1,10 +1,13 @@
 package com.clover.habbittracker.global.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 @Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class BaseResponse<T> {
 
 	private final String code;

--- a/src/test/java/com/clover/habbittracker/domain/diary/api/DiaryControllerTest.java
+++ b/src/test/java/com/clover/habbittracker/domain/diary/api/DiaryControllerTest.java
@@ -1,10 +1,14 @@
 package com.clover.habbittracker.domain.diary.api;
 
+import static com.clover.habbittracker.global.util.ApiDocumentUtils.*;
 import static com.clover.habbittracker.global.util.MemberProvider.*;
 import static org.hamcrest.core.Is.*;
 import static org.springframework.http.MediaType.*;
+import static org.springframework.restdocs.headers.HeaderDocumentation.*;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
+import static org.springframework.restdocs.payload.JsonFieldType.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import java.time.LocalDateTime;
@@ -13,6 +17,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.web.servlet.MockMvc;
@@ -28,6 +33,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 @SpringBootTest
 @AutoConfigureMockMvc
+@AutoConfigureRestDocs(uriScheme = "https", uriHost = "habiters.api.com")
 public class DiaryControllerTest {
 
 	@Autowired
@@ -54,7 +60,6 @@ public class DiaryControllerTest {
 			.build();
 		saveDiary = diaryRepository.save(diary);
 
-
 	}
 
 	@Test
@@ -66,12 +71,26 @@ public class DiaryControllerTest {
 
 		//when then
 		mockMvc.perform(
-			post("/diaries")
-				.header("Authorization","Bearer " + accessJwt)
-				.contentType(APPLICATION_JSON)
-				.content(request))
+				post("/diaries")
+					.header("Authorization", "Bearer " + accessJwt)
+					.contentType(APPLICATION_JSON)
+					.content(request))
 			.andExpect(status().isCreated())
-			.andDo(print());
+			// restDocs 설정.
+			.andDo(document("diary-create",
+				getDocumentRequest(),
+				getDocumentResponse(),
+				requestHeaders(
+					headerWithName("Authorization").description("JWT Access 토큰")
+				),
+				requestFields(
+					fieldWithPath("content").type(STRING).description("회고록 내용")
+				),
+				responseFields(
+					fieldWithPath("code").type(STRING).description("결과 코드"),
+					fieldWithPath("message").type(STRING).description("결과 메시지"),
+					fieldWithPath("data").type(NUMBER).description("생성된 회고 아이디")
+				)));
 	}
 
 	@Test
@@ -80,17 +99,34 @@ public class DiaryControllerTest {
 		//given
 		DiaryRequest diaryRequest = new DiaryRequest("회고록 수정내용 입니다.");
 		String request = new ObjectMapper().writeValueAsString(diaryRequest);
-
+		Long id = saveDiary.getId();
 		//when then
 		mockMvc.perform(
-				put("/diaries/"+ saveDiary.getId())
-					.header("Authorization","Bearer " + accessJwt)
+				put("/diaries/{diaryId}", id)
+					.header("Authorization", "Bearer " + accessJwt)
 					.contentType(APPLICATION_JSON)
 					.content(request))
 			.andExpect(status().isOk())
+			// 이 부분은 아래 restDocs로 검증하므로 빼야하는게 맞는걸까요?
 			.andExpect(jsonPath("$.data.id", is(saveDiary.getId().intValue())))
 			.andExpect(jsonPath("$.data.content", is(diaryRequest.getContent())))
-			.andDo(print());
+			// restDocs 설정.
+			.andDo(document("diary-update",
+				getDocumentRequest(),
+				getDocumentResponse(),
+				requestHeaders(
+					headerWithName("Authorization").description("JWT Access 토큰")
+				),
+				requestFields(
+					fieldWithPath("content").type(STRING).description("수정할 회고 내용")
+				),
+				responseFields(
+					fieldWithPath("code").type(STRING).description("결과 코드"),
+					fieldWithPath("message").type(STRING).description("결과 메시지"),
+					fieldWithPath("data.id").type(NUMBER).description("회고록 아이디"),
+					fieldWithPath("data.content").type(STRING).description("회고록 내용"),
+					fieldWithPath("data.createDate").type(STRING).description("회고록 등록 날짜")
+				)));
 	}
 
 	@Test
@@ -101,18 +137,65 @@ public class DiaryControllerTest {
 				get("/diaries")
 					.header("Authorization", "Bearer " + accessJwt))
 			.andExpect(status().isOk())
-			.andDo(print());
+			.andDo(document("all-diary-read",
+				getDocumentRequest(),
+				getDocumentResponse(),
+				requestHeaders(
+					headerWithName("Authorization").description("JWT Access 토큰")
+				),
+				responseFields(
+					fieldWithPath("code").type(STRING).description("결과 코드"),
+					fieldWithPath("message").type(STRING).description("결과 메시지"),
+					fieldWithPath("data[].id").type(NUMBER).description("회고록 아이디"),
+					fieldWithPath("data[].content").type(STRING).description("회고록 내용"),
+					fieldWithPath("data[].createDate").type(STRING).description("회고 등록 날짜")
+				)));
+	}
+
+	@Test
+	@DisplayName("사용자는 회고록을 월 별로 조회 할 수 있다.")
+	void getAMonthlyMyDiaryListTest() throws Exception {
+		String date = "2023-05";
+		//when then
+		mockMvc.perform(
+				get("/diaries")
+					.header("Authorization", "Bearer " + accessJwt)
+					.param("date", date))
+			.andExpect(status().isOk())
+			.andDo(document("monthly-diary-read",
+				getDocumentRequest(),
+				getDocumentResponse(),
+				requestHeaders(
+					headerWithName("Authorization").description("JWT Access 토큰")
+				),
+				responseFields(
+					fieldWithPath("code").type(STRING).description("결과 코드"),
+					fieldWithPath("message").type(STRING).description("결과 메시지"),
+					fieldWithPath("data[].id").type(NUMBER).description("회고록 아이디"),
+					fieldWithPath("data[].content").type(STRING).description("회고록 내용"),
+					fieldWithPath("data[].createDate").type(STRING).description("회고 등록 날짜")
+				)));
 	}
 
 	@Test
 	@DisplayName("사용자는 나의 회고록을 삭제 할 수 있다.")
 	void deleteDiaryTest() throws Exception {
+		Long id = saveDiary.getId();
 		//when then
 		mockMvc.perform(
-				delete("/diaries/" + saveDiary.getId())
+				delete("/diaries/{diaryId}" , id)
 					.header("Authorization", "Bearer " + accessJwt))
 			.andExpect(status().isNoContent())
-			.andDo(print());
+			.andDo(document("diary-delete",
+				getDocumentRequest(),
+				getDocumentResponse(),
+				requestHeaders(
+					headerWithName("Authorization").description("JWT Access 토큰")
+				),
+				responseFields(
+					fieldWithPath("code").type(STRING).description("결과 코드"),
+					fieldWithPath("message").type(STRING).description("결과 메시지")
+				)));
 	}
 
 	@Test
@@ -126,16 +209,26 @@ public class DiaryControllerTest {
 			.content("마감시간이 지난 회고록")
 			.build();
 		diaryRepository.save(expiredDiary);
+		Long expiredDiaryId = expiredDiary.getId();
 		//when then
 		mockMvc.perform(
-				put("/diaries/"+ expiredDiary.getId())
-					.header("Authorization","Bearer " + accessJwt)
+				put("/diaries/{diaryId}", expiredDiaryId)
+					.header("Authorization", "Bearer " + accessJwt)
 					.contentType(APPLICATION_JSON)
 					.content(request))
 			.andExpect(status().isBadRequest())
 			.andExpect(jsonPath("$.errorName", is(ErrorType.DIARY_EXPIRED.name())))
 			.andExpect(jsonPath("$.msg", is(ErrorType.DIARY_EXPIRED.getErrorMsg())))
-			.andDo(print());
+			.andDo(document("expired-diary",
+				getDocumentRequest(),
+				getDocumentResponse(),
+				requestHeaders(
+					headerWithName("Authorization").description("JWT Access 토큰")
+				),
+				responseFields(
+					fieldWithPath("errorName").type(STRING).description("결과 코드"),
+					fieldWithPath("msg").type(STRING).description("결과 메시지")
+				)));
 	}
 
 }

--- a/src/test/java/com/clover/habbittracker/domain/diary/api/DiaryControllerTest.java
+++ b/src/test/java/com/clover/habbittracker/domain/diary/api/DiaryControllerTest.java
@@ -8,6 +8,7 @@ import static org.springframework.restdocs.headers.HeaderDocumentation.*;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
 import static org.springframework.restdocs.payload.JsonFieldType.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -20,6 +21,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.test.web.servlet.MockMvc;
 
 import com.clover.habbittracker.domain.diary.dto.DiaryRequest;
@@ -102,7 +104,7 @@ public class DiaryControllerTest {
 		Long id = saveDiary.getId();
 		//when then
 		mockMvc.perform(
-				put("/diaries/{diaryId}", id)
+				RestDocumentationRequestBuilders.put("/diaries/{diaryId}", id)
 					.header("Authorization", "Bearer " + accessJwt)
 					.contentType(APPLICATION_JSON)
 					.content(request))
@@ -116,6 +118,9 @@ public class DiaryControllerTest {
 				getDocumentResponse(),
 				requestHeaders(
 					headerWithName("Authorization").description("JWT Access 토큰")
+				),
+				pathParameters(
+					parameterWithName("diaryId").description("수정할 회고 id")
 				),
 				requestFields(
 					fieldWithPath("content").type(STRING).description("수정할 회고 내용")
@@ -168,6 +173,9 @@ public class DiaryControllerTest {
 				requestHeaders(
 					headerWithName("Authorization").description("JWT Access 토큰")
 				),
+				queryParameters(
+					parameterWithName("date").description("조회하고 싶은 연 월")
+				),
 				responseFields(
 					fieldWithPath("code").type(STRING).description("결과 코드"),
 					fieldWithPath("message").type(STRING).description("결과 메시지"),
@@ -183,12 +191,15 @@ public class DiaryControllerTest {
 		Long id = saveDiary.getId();
 		//when then
 		mockMvc.perform(
-				delete("/diaries/{diaryId}" , id)
+				RestDocumentationRequestBuilders.delete("/diaries/{diaryId}" , id)
 					.header("Authorization", "Bearer " + accessJwt))
 			.andExpect(status().isNoContent())
 			.andDo(document("diary-delete",
 				getDocumentRequest(),
 				getDocumentResponse(),
+				pathParameters(
+					parameterWithName("diaryId").description("삭제할 회고 아이디")
+				),
 				requestHeaders(
 					headerWithName("Authorization").description("JWT Access 토큰")
 				),
@@ -212,7 +223,7 @@ public class DiaryControllerTest {
 		Long expiredDiaryId = expiredDiary.getId();
 		//when then
 		mockMvc.perform(
-				put("/diaries/{diaryId}", expiredDiaryId)
+				RestDocumentationRequestBuilders.put("/diaries/{diaryId}", expiredDiaryId)
 					.header("Authorization", "Bearer " + accessJwt)
 					.contentType(APPLICATION_JSON)
 					.content(request))
@@ -222,6 +233,9 @@ public class DiaryControllerTest {
 			.andDo(document("expired-diary",
 				getDocumentRequest(),
 				getDocumentResponse(),
+				pathParameters(
+					parameterWithName("diaryId").description("수정할 회고 아이디")
+				),
 				requestHeaders(
 					headerWithName("Authorization").description("JWT Access 토큰")
 				),

--- a/src/test/java/com/clover/habbittracker/domain/habit/api/HabitControllerTest.java
+++ b/src/test/java/com/clover/habbittracker/domain/habit/api/HabitControllerTest.java
@@ -170,7 +170,7 @@ public class HabitControllerTest {
 					headerWithName("Authorization").description("JWT Access 토큰")
 				),
 				pathParameters(
-					parameterWithName("habitId").description("습관 수행 여부를 체크할 아이디")
+					parameterWithName("habitId").description("습관 아이디")
 				),
 				responseFields(
 					fieldWithPath("code").type(STRING).description("결과 코드"),
@@ -187,14 +187,14 @@ public class HabitControllerTest {
 				RestDocumentationRequestBuilders.delete("/habits/{habitId}", testHabit.getId())
 					.header("Authorization", "Bearer " + accessJwt))
 			.andExpect(status().isNoContent())
-			.andDo(document("habitCheck-create",
+			.andDo(document("habitCheck-delete",
 				getDocumentRequest(),
 				getDocumentResponse(),
 				requestHeaders(
 					headerWithName("Authorization").description("JWT Access 토큰")
 				),
 				pathParameters(
-					parameterWithName("habitId").description("습관 수행 여부를 체크할 아이디")
+					parameterWithName("habitId").description("습관 아이디")
 				),
 				responseFields(
 					fieldWithPath("code").type(STRING).description("결과 코드"),

--- a/src/test/java/com/clover/habbittracker/domain/habit/api/HabitControllerTest.java
+++ b/src/test/java/com/clover/habbittracker/domain/habit/api/HabitControllerTest.java
@@ -230,6 +230,7 @@ public class HabitControllerTest {
 					fieldWithPath("data[].id").type(NUMBER).description("습관 아이디"),
 					fieldWithPath("data[].content").type(STRING).description("습관 내용"),
 					fieldWithPath("data[].createDate").type(STRING).description("습관 등록 날짜"),
+					fieldWithPath("data[].habitChecks[]").type(ARRAY).description("습관 체크 여부"),
 					fieldWithPath("data[].habitChecks[].id").type(NUMBER).description("습관 체크 여부 id"),
 					fieldWithPath("data[].habitChecks[].updatedAt").type(STRING).description("습관 수행 날짜")
 				)
@@ -265,6 +266,7 @@ public class HabitControllerTest {
 					fieldWithPath("data[].id").type(NUMBER).description("습관 아이디"),
 					fieldWithPath("data[].content").type(STRING).description("습관 내용"),
 					fieldWithPath("data[].createDate").type(STRING).description("습관 등록 날짜"),
+					fieldWithPath("data[].habitChecks[]").type(ARRAY).description("습관 체크 여부"),
 					fieldWithPath("data[].habitChecks[].id").type(NUMBER).description("습관 체크 여부 id"),
 					fieldWithPath("data[].habitChecks[].updatedAt").type(STRING).description("습관 수행 날짜")
 				)

--- a/src/test/java/com/clover/habbittracker/domain/habit/api/HabitControllerTest.java
+++ b/src/test/java/com/clover/habbittracker/domain/habit/api/HabitControllerTest.java
@@ -1,23 +1,32 @@
 package com.clover.habbittracker.domain.habit.api;
 
+import static com.clover.habbittracker.global.util.ApiDocumentUtils.*;
 import static com.clover.habbittracker.global.util.MemberProvider.*;
 import static org.hamcrest.core.Is.*;
 import static org.springframework.http.MediaType.*;
+import static org.springframework.restdocs.headers.HeaderDocumentation.*;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
+import static org.springframework.restdocs.payload.JsonFieldType.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.test.web.servlet.MockMvc;
 
 import com.clover.habbittracker.domain.habit.dto.HabitRequest;
 import com.clover.habbittracker.domain.habit.entity.Habit;
 import com.clover.habbittracker.domain.habit.repository.HabitRepository;
+import com.clover.habbittracker.domain.habitcheck.entity.HabitCheck;
+import com.clover.habbittracker.domain.habitcheck.repository.HabitCheckRepository;
 import com.clover.habbittracker.domain.member.entity.Member;
 import com.clover.habbittracker.domain.member.repository.MemberRepository;
 import com.clover.habbittracker.global.exception.ErrorType;
@@ -26,6 +35,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 @SpringBootTest
 @AutoConfigureMockMvc
+@AutoConfigureRestDocs(uriScheme = "https", uriHost = "habiters.api.com")
 public class HabitControllerTest {
 
 	@Autowired
@@ -36,6 +46,8 @@ public class HabitControllerTest {
 	private HabitRepository habitRepository;
 	@Autowired
 	private JwtProvider jwtProvider;
+	@Autowired
+	private HabitCheckRepository habitCheckRepository;
 
 	private String accessJwt;
 
@@ -64,7 +76,20 @@ public class HabitControllerTest {
 					.contentType(APPLICATION_JSON)
 					.content(request))
 			.andExpect(status().isCreated())
-			.andDo(print());
+			.andDo(document("habit-created",
+				getDocumentRequest(),
+				getDocumentResponse(),
+				requestHeaders(
+					headerWithName("Authorization").description("JWT Access 토큰")
+				),
+				requestFields(
+					fieldWithPath("content").type(STRING).description("등록할 습관 내용")
+				),
+				responseFields(
+					fieldWithPath("code").type(STRING).description("결과 코드"),
+					fieldWithPath("message").type(STRING).description("결과 메시지"),
+					fieldWithPath("data").type(NUMBER).description("등록된 습관 아이디")
+				)));
 	}
 
 	@Test
@@ -76,7 +101,7 @@ public class HabitControllerTest {
 
 		//when
 		mockMvc.perform(
-				put("/habits/" + testHabit.getId())
+				RestDocumentationRequestBuilders.put("/habits/{habitId}", testHabit.getId())
 					.header("Authorization", "Bearer " + accessJwt)
 					.contentType(APPLICATION_JSON)
 					.content(request))
@@ -84,7 +109,26 @@ public class HabitControllerTest {
 			.andExpect(jsonPath("$.data.id").exists())
 			.andExpect(jsonPath("$.data.content").exists())
 			.andExpect(jsonPath("$.data.createDate").exists())
-			.andDo(print());
+			.andDo(document("habit-update",
+				getDocumentRequest(),
+				getDocumentResponse(),
+				requestHeaders(
+					headerWithName("Authorization").description("JWT Access 토큰")
+				),
+				pathParameters(
+					parameterWithName("habitId").description("수정할 습관 아이디")
+				),
+				requestFields(
+					fieldWithPath("content").description("수정할 습관 내용")
+				),
+				responseFields(
+					fieldWithPath("code").type(STRING).description("결과 코드"),
+					fieldWithPath("message").type(STRING).description("결과 메시지"),
+					fieldWithPath("data.id").type(NUMBER).description("습관 아이디"),
+					fieldWithPath("data.content").type(STRING).description("습관 내용"),
+					fieldWithPath("data.createDate").type(STRING).description("습관 등록 날짜")
+				)
+			));
 	}
 
 	@Test
@@ -92,10 +136,23 @@ public class HabitControllerTest {
 	void deleteHabitTest() throws Exception {
 		//when then
 		mockMvc.perform(
-				delete("/habits/" + testHabit.getId())
+				RestDocumentationRequestBuilders.delete("/habits/{habitId}" , testHabit.getId())
 					.header("Authorization", "Bearer " + accessJwt))
 			.andExpect(status().isNoContent())
-			.andDo(print());
+			.andDo(document("habit-delete",
+				getDocumentRequest(),
+				getDocumentResponse(),
+				requestHeaders(
+					headerWithName("Authorization").description("JWT Access 토큰")
+				),
+				pathParameters(
+					parameterWithName("habitId").description("삭제할 습관 아이디")
+				),
+				responseFields(
+					fieldWithPath("code").type(STRING).description("결과 코드"),
+					fieldWithPath("message").type(STRING).description("결과 메시지")
+				)
+				));
 	}
 
 	@Test
@@ -103,10 +160,23 @@ public class HabitControllerTest {
 	void habitCheckTest() throws Exception {
 		//when then
 		mockMvc.perform(
-				post("/habits/" + testHabit.getId() + "/check")
+				RestDocumentationRequestBuilders.post("/habits/{habitId}/check"  ,testHabit.getId())
 					.header("Authorization", "Bearer " + accessJwt))
 			.andExpect(status().isCreated())
-			.andDo(print());
+			.andDo(document("habitCheck-create",
+				getDocumentRequest(),
+				getDocumentResponse(),
+				requestHeaders(
+					headerWithName("Authorization").description("JWT Access 토큰")
+				),
+				pathParameters(
+					parameterWithName("habitId").description("습관 수행 여부를 체크할 아이디")
+				),
+				responseFields(
+					fieldWithPath("code").type(STRING).description("결과 코드"),
+					fieldWithPath("message").type(STRING).description("결과 메시지")
+				)
+			));
 	}
 
 	@Test
@@ -114,26 +184,91 @@ public class HabitControllerTest {
 	void habitUnCheckTest() throws Exception {
 		//when then
 		mockMvc.perform(
-				delete("/habits/" + testHabit.getId() + "/check")
+				RestDocumentationRequestBuilders.delete("/habits/{habitId}", testHabit.getId())
 					.header("Authorization", "Bearer " + accessJwt))
 			.andExpect(status().isNoContent())
-			.andDo(print());
+			.andDo(document("habitCheck-create",
+				getDocumentRequest(),
+				getDocumentResponse(),
+				requestHeaders(
+					headerWithName("Authorization").description("JWT Access 토큰")
+				),
+				pathParameters(
+					parameterWithName("habitId").description("습관 수행 여부를 체크할 아이디")
+				),
+				responseFields(
+					fieldWithPath("code").type(STRING).description("결과 코드"),
+					fieldWithPath("message").type(STRING).description("결과 메시지")
+				)
+			));
 	}
 
 	@Test
 	@DisplayName("사용자는 나의 습관 리스트와 습관 수행 여부를 조회 할 수 있다.")
 	void myHabitListTest() throws Exception {
+		//given
+		HabitCheck testHabitCheck = HabitCheck.builder().habit(testHabit).checked(true).build();
+		habitCheckRepository.save(testHabitCheck);
 
 		mockMvc.perform(
 				get("/habits")
-					.header("Authorization", "Bearer " + accessJwt)
-					.param("date", "2023-04"))
+					.header("Authorization", "Bearer " + accessJwt))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.data.[0].id").exists())
 			.andExpect(jsonPath("$.data.[0].content").exists())
 			.andExpect(jsonPath("$.data.[0].createDate").exists())
 			.andExpect(jsonPath("$.data.[0].habitChecks").exists())
-			.andDo(print());
+			.andDo(document("habit-read",
+				getDocumentRequest(),
+				getDocumentResponse(),
+				requestHeaders(
+					headerWithName("Authorization").description("JWT Access 토큰")
+				),
+				responseFields(
+					fieldWithPath("code").type(STRING).description("결과 코드"),
+					fieldWithPath("message").type(STRING).description("결과 메시지"),
+					fieldWithPath("data[].id").type(NUMBER).description("습관 아이디"),
+					fieldWithPath("data[].content").type(STRING).description("습관 내용"),
+					fieldWithPath("data[].createDate").type(STRING).description("습관 등록 날짜"),
+					fieldWithPath("data[].habitChecks[].id").type(NUMBER).description("습관 체크 여부 id"),
+					fieldWithPath("data[].habitChecks[].updatedAt").type(STRING).description("습관 수행 날짜")
+				)
+			));
+	}
+	@Test
+	@DisplayName("사용자는 나의 습관 리스트와 습관 수행 여부를 월 별로 조회 할 수 있다.")
+	void monthlyMyHabitListTest() throws Exception {
+		//given
+		HabitCheck testHabitCheck = HabitCheck.builder().habit(testHabit).checked(true).build();
+		habitCheckRepository.save(testHabitCheck);
+
+		mockMvc.perform(
+				get("/habits")
+					.header("Authorization", "Bearer " + accessJwt).param("date","2023-05"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.[0].id").exists())
+			.andExpect(jsonPath("$.data.[0].content").exists())
+			.andExpect(jsonPath("$.data.[0].createDate").exists())
+			.andExpect(jsonPath("$.data.[0].habitChecks").exists())
+			.andDo(document("monthly-habit-read",
+				getDocumentRequest(),
+				getDocumentResponse(),
+				requestHeaders(
+					headerWithName("Authorization").description("JWT Access 토큰")
+				),
+				queryParameters(
+					parameterWithName("date").description("조회 하고 싶은 연 월")
+				),
+				responseFields(
+					fieldWithPath("code").type(STRING).description("결과 코드"),
+					fieldWithPath("message").type(STRING).description("결과 메시지"),
+					fieldWithPath("data[].id").type(NUMBER).description("습관 아이디"),
+					fieldWithPath("data[].content").type(STRING).description("습관 내용"),
+					fieldWithPath("data[].createDate").type(STRING).description("습관 등록 날짜"),
+					fieldWithPath("data[].habitChecks[].id").type(NUMBER).description("습관 체크 여부 id"),
+					fieldWithPath("data[].habitChecks[].updatedAt").type(STRING).description("습관 수행 날짜")
+				)
+			));
 	}
 
 	@Test
@@ -141,12 +276,24 @@ public class HabitControllerTest {
 	void habitCheckTestWithWrongId() throws Exception {
 		long wrongId = 0L;
 		mockMvc.perform(
-				post("/habits/" + wrongId + "/check")
+				RestDocumentationRequestBuilders.post("/habits/{habitId}/check", wrongId)
 					.header("Authorization", "Bearer " + accessJwt))
 			.andExpect(status().isNotFound())
 			.andExpect(jsonPath("$.errorName", is(ErrorType.HABIT_NOT_FOUND.name())))
 			.andExpect(jsonPath("$.msg", is(ErrorType.HABIT_NOT_FOUND.getErrorMsg())))
-			.andDo(print());
+			.andDo(document("notfound-Habit",
+				getDocumentRequest(),
+				getDocumentResponse(),
+				pathParameters(
+					parameterWithName("habitId").description("잘못된 습관 아이디")
+				),
+				requestHeaders(
+					headerWithName("Authorization").description("JWT Access 토큰")
+				),
+				responseFields(
+					fieldWithPath("errorName").type(STRING).description("결과 코드"),
+					fieldWithPath("msg").type(STRING).description("결과 메시지")
+				)));
 	}
 
 	@Test
@@ -156,16 +303,28 @@ public class HabitControllerTest {
 
 		//when then
 		mockMvc.perform(
-			post("/habits/" + testHabit.getId() + "/check")
+			post("/habits/{habitId}/check" , testHabit.getId())
 				.header("Authorization", "Bearer " + accessJwt));
 
 		mockMvc.perform(
-			post("/habits/" + testHabit.getId() + "/check")
-				.header("Authorization", "Bearer " + accessJwt))
+				RestDocumentationRequestBuilders.post("/habits/{habitId}/check" , testHabit.getId())
+					.header("Authorization", "Bearer " + accessJwt))
 			.andExpect(status().isConflict())
 			.andExpect(jsonPath("$.errorName", is(ErrorType.HABIT_CHECK_DUPLICATE.name())))
 			.andExpect(jsonPath("$.msg", is(ErrorType.HABIT_CHECK_DUPLICATE.getErrorMsg())))
-			.andDo(print());
+			.andDo(document("Duplicate-HabitCheck",
+				getDocumentRequest(),
+				getDocumentResponse(),
+				pathParameters(
+					parameterWithName("habitId").description("습관 아이디")
+				),
+				requestHeaders(
+					headerWithName("Authorization").description("JWT Access 토큰")
+				),
+				responseFields(
+					fieldWithPath("errorName").type(STRING).description("결과 코드"),
+					fieldWithPath("msg").type(STRING).description("결과 메시지")
+				)));
 
 	}
 

--- a/src/test/java/com/clover/habbittracker/domain/member/api/MemberControllerTest.java
+++ b/src/test/java/com/clover/habbittracker/domain/member/api/MemberControllerTest.java
@@ -1,17 +1,23 @@
 package com.clover.habbittracker.domain.member.api;
 
+import static com.clover.habbittracker.global.util.ApiDocumentUtils.*;
 import static com.clover.habbittracker.global.util.MemberProvider.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.hamcrest.core.Is.*;
 import static org.springframework.http.MediaType.*;
+import static org.springframework.restdocs.headers.HeaderDocumentation.*;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
+import static org.springframework.restdocs.payload.JsonFieldType.STRING;
+import static org.springframework.restdocs.payload.JsonFieldType.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.web.servlet.MockMvc;
@@ -23,8 +29,11 @@ import com.clover.habbittracker.domain.member.repository.MemberRepository;
 import com.clover.habbittracker.global.security.jwt.JwtProvider;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-@SpringBootTest(properties = { "spring.datasource.url=jdbc:h2:mem:testdb", "spring.datasource.driver-class-name=org.h2.Driver", "spring.datasource.username=sa", "spring.datasource.password=" })
+@SpringBootTest(properties = {"spring.datasource.url=jdbc:h2:mem:testdb",
+	"spring.datasource.driver-class-name=org.h2.Driver", "spring.datasource.username=sa",
+	"spring.datasource.password="})
 @AutoConfigureMockMvc
+@AutoConfigureRestDocs(uriScheme = "https", uriHost = "habiters.api.com")
 public class MemberControllerTest {
 
 	@Autowired
@@ -43,18 +52,32 @@ public class MemberControllerTest {
 		accessJwt = jwtProvider.createAccessJwt(1L);
 	}
 
-
 	@Test
 	@DisplayName("사용자는 자신의 프로필 정보를 조회할수있다.")
 	void getMyProfileTest() throws Exception {
 		//when then
-		mockMvc.perform(get("/users/me").header("Authorization","Bearer " + accessJwt))
+		mockMvc.perform(get("/users/me")
+				.header("Authorization", "Bearer " + accessJwt))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.data.id").exists())
 			.andExpect(jsonPath("$.data.email").exists())
 			.andExpect(jsonPath("$.data.nickName").exists())
 			.andExpect(jsonPath("$.data.profileImgUrl").exists())
-			.andDo(print());
+			.andDo(document("member-read",
+				getDocumentRequest(),
+				getDocumentResponse(),
+				requestHeaders(
+					headerWithName("Authorization").description("JWT Access 토큰")
+				),
+				responseFields(
+					fieldWithPath("code").type(STRING).description("결과 코드"),
+					fieldWithPath("message").type(STRING).description("결과 메시지"),
+					fieldWithPath("data.id").type(NUMBER).description("회원 아이디"),
+					fieldWithPath("data.email").type(STRING).description("회원 이메일"),
+					fieldWithPath("data.nickName").type(STRING).description("회원 닉네임"),
+					fieldWithPath("data.profileImgUrl").type(STRING).description("회원 프로필 사진 URL")
+				)
+			));
 	}
 
 	@Test
@@ -69,14 +92,33 @@ public class MemberControllerTest {
 
 		//when then
 		mockMvc.perform(put("/users/me")
-				.header("Authorization","Bearer " + accessJwt)
+				.header("Authorization", "Bearer " + accessJwt)
 				.contentType(APPLICATION_JSON)
 				.content(request))
 			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.data.nickName",is("updateNickName")))
-			.andExpect(jsonPath("$.data.profileImgUrl",is("updateProfileImgUrl")))
-			.andDo(print());
+			.andExpect(jsonPath("$.data.nickName", is("updateNickName")))
+			.andExpect(jsonPath("$.data.profileImgUrl", is("updateProfileImgUrl")))
+			.andDo(document("member-update",
+				getDocumentRequest(),
+				getDocumentResponse(),
+				requestHeaders(
+					headerWithName("Authorization").description("JWT Access 토큰")
+				),
+				requestFields(
+					fieldWithPath("nickName").description("수정할 닉네임"),
+					fieldWithPath("profileImgUrl").description("수정할 프로필 사진 URL")
+				),
+				responseFields(
+					fieldWithPath("code").type(STRING).description("결과 코드"),
+					fieldWithPath("message").type(STRING).description("결과 메시지"),
+					fieldWithPath("data.id").type(NUMBER).description("회원 아이디"),
+					fieldWithPath("data.email").type(STRING).description("회원 이메일"),
+					fieldWithPath("data.nickName").type(STRING).description("회원 닉네임"),
+					fieldWithPath("data.profileImgUrl").type(STRING).description("회원 프로필 사진 URL")
+				)
+			));
 	}
+
 	@Test
 	@DisplayName("기존의 사용하고 있는 닉네임은 중복으로 생각하여 예외가 발생한다.")
 	void updateNickNameDuplicateTest() throws Exception {
@@ -91,9 +133,19 @@ public class MemberControllerTest {
 				.header("Authorization", "Bearer " + accessJwt)
 				.contentType(APPLICATION_JSON)
 				.content(request))
-			.andExpect(result -> assertThat(result.getResolvedException()).isInstanceOf(IllegalArgumentException.class));
+			.andExpect(
+				result -> assertThat(result.getResolvedException()).isInstanceOf(IllegalArgumentException.class))
+			.andDo(document("duplicate-member",
+				getDocumentRequest(),
+				getDocumentResponse(),
+				requestHeaders(
+					headerWithName("Authorization").description("JWT Access 토큰")
+				),
+				responseFields(
+					fieldWithPath("errorName").type(STRING).description("결과 코드"),
+					fieldWithPath("msg").type(STRING).description("결과 메시지")
+				)));
 	}
-
 
 	@Test
 	@DisplayName("사용자는 자신의 프로필 정보를 삭제 할 수 있다.")
@@ -113,6 +165,16 @@ public class MemberControllerTest {
 		//when then
 		mockMvc.perform(delete("/users/me").header("Authorization", "Bearer " + deleteMemberToken))
 			.andExpect(status().isNoContent())
-			.andDo(print());
+			.andDo(document("member-update",
+				getDocumentRequest(),
+				getDocumentResponse(),
+				requestHeaders(
+					headerWithName("Authorization").description("JWT Access 토큰")
+				),
+				responseFields(
+					fieldWithPath("code").type(STRING).description("결과 코드"),
+					fieldWithPath("message").type(STRING).description("결과 메시지")
+				)
+			));
 	}
 }

--- a/src/test/java/com/clover/habbittracker/domain/member/api/MemberControllerTest.java
+++ b/src/test/java/com/clover/habbittracker/domain/member/api/MemberControllerTest.java
@@ -165,7 +165,7 @@ public class MemberControllerTest {
 		//when then
 		mockMvc.perform(delete("/users/me").header("Authorization", "Bearer " + deleteMemberToken))
 			.andExpect(status().isNoContent())
-			.andDo(document("member-update",
+			.andDo(document("member-delete",
 				getDocumentRequest(),
 				getDocumentResponse(),
 				requestHeaders(

--- a/src/test/java/com/clover/habbittracker/global/util/ApiDocumentUtils.java
+++ b/src/test/java/com/clover/habbittracker/global/util/ApiDocumentUtils.java
@@ -1,0 +1,17 @@
+package com.clover.habbittracker.global.util;
+
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+
+import org.springframework.restdocs.operation.preprocess.OperationRequestPreprocessor;
+import org.springframework.restdocs.operation.preprocess.OperationResponsePreprocessor;
+
+public interface ApiDocumentUtils {
+
+	static OperationRequestPreprocessor getDocumentRequest() {
+		return preprocessRequest(modifyUris().scheme("https").host("habiters.api.com").removePort(), prettyPrint());
+	}
+
+	static OperationResponsePreprocessor getDocumentResponse() {
+		return preprocessResponse(prettyPrint());
+	}
+}

--- a/src/test/resources/org/springframework/restdocs/templates/path-parameters.snippet
+++ b/src/test/resources/org/springframework/restdocs/templates/path-parameters.snippet
@@ -1,0 +1,11 @@
+===== Path Parameters
+
+|===
+|경로 변수|설명
+
+{{#parameters}}
+|{{#tableCellContent}}`+{{name}}+`{{/tableCellContent}}
+|{{#tableCellContent}}{{description}}{{/tableCellContent}}
+
+{{/parameters}}
+|===

--- a/src/test/resources/org/springframework/restdocs/templates/request-fields.snippet
+++ b/src/test/resources/org/springframework/restdocs/templates/request-fields.snippet
@@ -1,0 +1,11 @@
+===== Request Fields
+
+|===
+|필드명|타입|필수값|설명
+{{#fields}}
+	|{{#tableCellContent}}`+{{path}}+`{{/tableCellContent}}
+	|{{#tableCellContent}}`+{{type}}+`{{/tableCellContent}}
+	|{{#tableCellContent}}{{^optional}}true{{/optional}}{{/tableCellContent}}
+	|{{#tableCellContent}}{{description}}{{/tableCellContent}}
+{{/fields}}
+|===

--- a/src/test/resources/org/springframework/restdocs/templates/request-headers.snippet
+++ b/src/test/resources/org/springframework/restdocs/templates/request-headers.snippet
@@ -1,0 +1,10 @@
+===== Request Header
+
+|===
+
+|헤더|설명
+{{#headers}}
+	|{{#tableCellContent}}`+{{name}}+`{{/tableCellContent}}
+	|{{#tableCellContent}}{{description}}{{/tableCellContent}}
+{{/headers}}
+|===

--- a/src/test/resources/org/springframework/restdocs/templates/request-parameters.snippet
+++ b/src/test/resources/org/springframework/restdocs/templates/request-parameters.snippet
@@ -1,0 +1,12 @@
+===== Request Parameters
+
+|===
+|변수명|필수값|설명
+
+{{#parameters}}
+|{{#tableCellContent}}`+{{name}}+`{{/tableCellContent}}
+|{{#tableCellContent}}{{^optional}}true{{/optional}}{{/tableCellContent}}
+|{{#tableCellContent}}{{description}}{{/tableCellContent}}
+
+{{/parameters}}
+|===

--- a/src/test/resources/org/springframework/restdocs/templates/response-fields.snippet
+++ b/src/test/resources/org/springframework/restdocs/templates/response-fields.snippet
@@ -1,0 +1,12 @@
+===== Response Fields
+
+|===
+|필드명|타입|설명
+
+{{#fields}}
+|{{#tableCellContent}}`+{{path}}+`{{/tableCellContent}}
+|{{#tableCellContent}}`+{{type}}+`{{/tableCellContent}}
+|{{#tableCellContent}}{{description}}{{/tableCellContent}}
+
+{{/fields}}
+|===


### PR DESCRIPTION
## 작업 사항
[config(restDocs) : Rest Docs 설정 추가](https://github.com/potenday-project/Habiters_BE/commit/144ca4d34183db431f3a7eed9d7375ba4723f999) 
- Spring Rest Docs 를 사용하기 위해 restdocs 의존성을 추가했습니다.
- restdocs 의 mockmvc 와 asciidoctor을 추가했습니다.
- asciidoctor 에 test task 를 의존성 추가하여, test 가 실행 된 후 asciidoctor을 실행 하도록 설정하였습니다.
- bootJar 에 asciidoctor 의존성을 추가하여 bootJar task 가 실행 되기전에 asciidoctor 를 실행하여, .adoc 파일을 html 문서로 만들도록 설정하였습니다.
- 해당 설정은 github 코드 리뷰에 작성하도록 하겠습니다.

[chore(dto) : BaseResponse JsonInclude 설정 추가](https://github.com/potenday-project/Habiters_BE/commit/682bc1e3edaf6d4cd0bc3755b753923a89929899) 
- Jackson 어노테이션을 활용하여, 속성의 값이 null 이 들어온다면 직렬화를 하지 않는다는 설정을 추가했습니다.
- 해당 설정을 한 이유는 'data' 의 값이 Null 이 들어 올 수 있기 때문에 Null을 반환하기 보다는 애초에 직렬화를 하지 않기에 기존 보다 안정성이 높을 거라 생각되어 추가했습니다.

[feat(Test_Diary) : RestDocs 추가](https://github.com/potenday-project/Habiters_BE/commit/ead22e0cefa0728c672eec5fde5fff396659cca4) 
- 기존 postman 으로 작성 되어 있는 api 문서를 자동화 하기 위하여 RestDocs를 추가 하였습니다.
- 테스트가 성공 해야만 문서가 작성 되기 떄문에, api 의 신뢰도를 높이기 위해 적절하다고 생각하여 적용했습니다.
- gradle 설정에 따라 .adoc 파일을 먼저 생성 후 html 문서화 하여 볼 수 있습니다.
- document 함수를 실행하여, restDoc 문서를 만들며, 제일 첫번째 매개변수는 해당 .adoc 파일이 생성되는 디렉토리의 이름을 정의합니다.
- ApiDocumentUtils 클래스를 생성하여 getDocumentRequest, getDocumentResponse 함수로 request와 response 문서의 설정을 추가하였습니다.
- @AutoConfigureRestDocs 어노테이션으로 RestDocs 객체를 자동 주입하도록 하였습니다.
- 생성된 html 문서는 habiters.api.com 으로 볼 수 있게 설정해보았습니다.

[feat(Test_Utils) : ApiDocumentUtils 추가](https://github.com/potenday-project/Habiters_BE/commit/a3f12eaa6841f950c580caa2ee603663bed98b2c) 
- Request 와 Response 문서를 어떻게 설정 할 것인지 정의한 클래스입니다.
- 문서상 uri 를 기본값인 http://localhost:8080 에서 https://habiters.api.com/ 으로 변경하기 위해 사용합니다.
- 문서의 출력을 들여쓰기를 사용하기 위해 prettyPrint 를 response,request 에 각각 설정하였습니다.