### PR TITLE
Feat: https 추가

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,17 @@ networks:
     driver: bridge
 
 services:
+  certbot:
+    image: certbot/certbot
+    container_name: certbot
+    depends_on:
+      - nginx
+    volumes:
+      - ./certbot/conf:/etc/letsencrypt
+      - ./certbot/www:/var/www/certbot
+    command: certonly --webroot --webroot-path=/var/www/certbot --email xogmlwkdi77@gmail.com --agree-tos --no-eff-email --force-renewal -d api.habiters.store
+    networks:
+      - habiters-network
   nginx:
     container_name: habiters-nginx
     image: nginx
@@ -11,8 +22,11 @@ services:
       - web
     volumes:
       - ./nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./certbot/conf:/etc/letsencrypt
+      - ./certbot/www:/var/www/certbot
     ports:
-      - 80:80
+      - "80:80"
+      - "443:443"
     networks:
       - habiters-network
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -11,7 +11,23 @@ http {
 
   server {
     listen 80;
-    server_name localhost;
+    server_name api.habiters.store;
+
+    location /.well-known/acme-challenge {
+      root /var/www/certbot;
+    }
+
+    location / {
+      return 301 https://$host$request_uri;
+    }
+  }
+
+  server {
+    listen 443 ssl;
+    server_name api.habiters.store;
+
+    ssl_certificate /etc/letsencrypt/live/api.habiters.store/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/api.habiters.store/privkey.pem;
 
     location / {
       proxy_pass http://web:8080;  # API 서버로 프록시

--- a/src/main/java/com/clover/habbittracker/global/util/CookieUtil.java
+++ b/src/main/java/com/clover/habbittracker/global/util/CookieUtil.java
@@ -34,7 +34,7 @@ public class CookieUtil {
 		Cookie cookie = new Cookie(name, value);
 		cookie.setPath("/");
 		cookie.setHttpOnly(true);
-		cookie.setSecure(false);
+		cookie.setSecure(true);
 		cookie.setMaxAge(maxAge);
 		response.addCookie(cookie);
 	}


### PR DESCRIPTION
### 작업 사항
[feat(docker) : nginx https 추가](https://github.com/potenday-project/Habiters_BE/commit/77a57f5e96b47a7372bdcedc04db217705a5b886) 
- certbot 을 이용하여 ssl 인증서를 발급 후 해당 인증서를 443 포트로 설정하였습니다.
- http 로 요청이 오면 https 로 리다이렉션하도록 설정하였습니다.

[feat(docker) : docker-compose https 추가](https://github.com/potenday-project/Habiters_BE/commit/89e23294eb8b2e29aa730159d858a1ed6c48b4dc) 
- certbot 으로 ssl 인증서를 발급 받은 후 nginx 에서 443 포트를 사용시 certbot 에서 발급받은 ssl 인증서를 사용하도록 설정하였습니다.


### 이슈 사항
- https 를 사용하기 위해 ceertbot 을 설정 하였지만, certbot은 nginx 가 켜져있어야 인증서를 발급 받을 수 있으며,
 nginx 는 ssl 인증서를 받은 후 nginx.conf 파일을 변경해야 하는 문제가 있었습니다.
- 해당 이슈를 해결하기 위해 많은 생각을 해봤지만.. 지금으로서는 해결하기 힘들어 임시 조치로 서버에서 직접 ssl 인증을 미리 받은 후 인증서를 서버 내에 데이터를 만든 후에 compose 파일을 실행 하도록 했습니다.
- docker 와 nginx, certbot 을 제대로 이해하지 못한 상태로 하려 하다보니 이렇게 처리하게 되었습니다... 추후에 공부를 더 한 후에 무중단 배포로 https 를 제대로 동작하게 수정할 예정입니다.