### PR TITLE
Fix: HabitCheck 삭제 오류 수정

### DIFF
--- a/src/main/java/com/clover/habbittracker/domain/habit/api/HabitController.java
+++ b/src/main/java/com/clover/habbittracker/domain/habit/api/HabitController.java
@@ -74,9 +74,9 @@ public class HabitController {
 		return ResponseEntity.status(HttpStatus.CREATED).body(response);
 	}
 
-	@DeleteMapping("{habitId}/check")
-	public ResponseEntity<BaseResponse<Void>> HabitUnCheck(@PathVariable Long habitId) {
-		habitService.habitUnCheck(habitId);
+	@DeleteMapping("{habitCheckId}/uncheck")
+	public ResponseEntity<BaseResponse<Void>> HabitUnCheck(@PathVariable Long habitCheckId) {
+		habitService.habitUnCheck(habitCheckId);
 		BaseResponse<Void> response = BaseResponse.of(null, HABIT_CHECK_DELETE);
 		return ResponseEntity.status(HttpStatus.NO_CONTENT).body(response);
 	}

--- a/src/main/java/com/clover/habbittracker/domain/habit/service/HabitService.java
+++ b/src/main/java/com/clover/habbittracker/domain/habit/service/HabitService.java
@@ -17,5 +17,5 @@ public interface HabitService {
 
 	void deleteHabit(Long habitId);
 
-	void habitUnCheck(Long habitId);
+	void habitUnCheck(Long habitCheckId);
 }

--- a/src/main/java/com/clover/habbittracker/domain/habit/service/HabitServiceImpl.java
+++ b/src/main/java/com/clover/habbittracker/domain/habit/service/HabitServiceImpl.java
@@ -77,6 +77,7 @@ public class HabitServiceImpl implements HabitService {
 		habitCheckRepository.findByHabitOrderByUpdatedAtDesc(habit)
 			.ifPresent(lastHabitCheck -> {
 				if (isToday(lastHabitCheck.getUpdatedAt().toLocalDate())) {
+					System.out.println(lastHabitCheck.getUpdatedAt());
 					throw new HabitCheckDuplicateException(habitId);
 				}
 			});
@@ -90,18 +91,8 @@ public class HabitServiceImpl implements HabitService {
 	}
 
 	@Override
-	public void habitUnCheck(Long habitId) {
-		Habit habit = habitRepository.findById(habitId)
-			.orElseThrow(()-> new HabitNotFoundException(habitId));
-
-		habitCheckRepository.findByHabit(habit)
-			.ifPresent(habitCheck -> habitCheckRepository.deleteById(habitCheck.getId()));
-		// habitCheckRepository.findByHabitOrderByUpdatedAtDesc(habit)
-		// 	.ifPresent(lastHabitCheck -> {
-		// 		if (validDate(lastHabitCheck.getUpdatedAt())) {
-		// 			throw new HabitException("같은 날 두번 체크는 불가능합니다.");
-		// 		}
-		// 	});
+	public void habitUnCheck(Long habitCheckId) {
+		habitCheckRepository.deleteById(habitCheckId);
 	}
 
 	private boolean isToday(LocalDate dateTime) {

--- a/src/test/java/com/clover/habbittracker/domain/habit/api/HabitControllerTest.java
+++ b/src/test/java/com/clover/habbittracker/domain/habit/api/HabitControllerTest.java
@@ -196,9 +196,11 @@ public class HabitControllerTest {
 	@Test
 	@DisplayName("사용자는 저장된 습관 수행 여부를 취소 할 수 있다.")
 	void habitUnCheckTest() throws Exception {
+		HabitCheck toBeErased = HabitCheck.builder().checked(true).habit(testHabit).build();
+		habitCheckRepository.save(toBeErased);
 		//when then
 		mockMvc.perform(
-				RestDocumentationRequestBuilders.delete("/habits/{habitId}", testHabit.getId())
+				RestDocumentationRequestBuilders.delete("/habits/{habitCheckId}/uncheck", toBeErased.getId())
 					.header("Authorization", "Bearer " + accessJwt))
 			.andExpect(status().isNoContent())
 			.andDo(document("habitCheck-delete",
@@ -208,7 +210,7 @@ public class HabitControllerTest {
 					headerWithName("Authorization").description("JWT Access 토큰")
 				),
 				pathParameters(
-					parameterWithName("habitId").description("습관 아이디")
+					parameterWithName("habitCheckId").description("습관체크 아이디")
 				),
 				responseFields(
 					fieldWithPath("code").type(STRING).description("결과 코드"),
@@ -357,7 +359,7 @@ public class HabitControllerTest {
 
 	}
 	@Test
-	@DisplayName("습관 수행 여부를 중복 체크 하면 HabitCheckDuplicate 예외가 터진다.")
+	@DisplayName("습관 수행 여부를 체크 할 경우 과거 또는 미래를 체크 할 경우 HabitExpiredException 예외가 터진다.")
 	void habitCheckTestWithExpiredDate() throws Exception {
 		//given
 		LocalDate yesterday = LocalDate.now().minusDays(1);

--- a/src/test/java/com/clover/habbittracker/domain/habit/service/HabitServiceTest.java
+++ b/src/test/java/com/clover/habbittracker/domain/habit/service/HabitServiceTest.java
@@ -184,16 +184,15 @@ public class HabitServiceTest {
 		Long testMemberId = testMember.getId();
 		HabitRequest habitRequest = new HabitRequest("테스트습관");
 		Long saveHabitId = habitService.register(testMemberId, habitRequest);
-		Habit saveHabit = habitRepository.findById(saveHabitId).get();
 		String today = "0" + now.getMonthValue() + "-" + now.getDayOfMonth();
-
+		Long toBeErasedCheckId = 1L;
 		habitService.habitCheck(saveHabitId, today);
 
 		//when
-		habitService.habitUnCheck(saveHabitId);
+		habitService.habitUnCheck(toBeErasedCheckId);
 
 		//then
-		Optional<HabitCheck> unCheckHabit = habitCheckRepository.findByHabit(saveHabit);
+		Optional<HabitCheck> unCheckHabit = habitCheckRepository.findById(toBeErasedCheckId);
 		assertThat(unCheckHabit).isEmpty();
 	}
 
@@ -208,7 +207,6 @@ public class HabitServiceTest {
 		//when then
 		assertAll(
 			() -> assertThrows(HabitNotFoundException.class, () -> habitService.habitCheck(wrongHabitId , today)),
-			() -> assertThrows(HabitNotFoundException.class, () -> habitService.habitUnCheck(wrongHabitId)),
 			() -> assertThrows(HabitNotFoundException.class,
 				() -> habitService.updateMyHabit(wrongHabitId, habitRequest))
 		);


### PR DESCRIPTION
## 작업 사항
**HabitCheck 삭제 시 NonUniqueResultException 예외가 발생하였습니다. 
NonUniqueResultException 은 쿼리 결과가 유일하지 않을 때 발생하는 예외입니다. 일반적으로 JPA의 `getSingleResult()` 메서드를 사용하여 단일 결과를 가져오려고 할 때 발생합니다.**

**HabitCheck 삭제 시 기존은 Habit_Id로 찾아, HabitCheck_Id 를 찾아 삭제 하도록 구현했지만, Habit 안에는 HabitCheck가 반드시 List 형태로 반환되어야 합니다. 따라서 HabitCheck 삭제 url 과 메소드를 수정하였습니다🥲**


[fix(Controller) : HabitUnCheck url 수정](https://github.com/potenday-project/Habiters_BE/commit/16f3c6235f29eedb3d29748564f229590a442ffd) 
- Habit 기준으로 Url 을 전부 맞추기위해 잘못된 설계를 하여 전체적으로 수정하였습니다.
- HabitCheck 를 삭제할 때 기존은 HabitId를 받은 후 HabitCheck 데이터를 삭제하도록 했었지만,
Habit 안에 HabitCheck 는 List 형태로 어떤 HabitCheck 를 삭제해야 하는지 알수가 없는 문제가 생겼습니다.
- 해당 오류를 수정하기 위하여 HabitId 에서 HabitCheckId 를 변수로 받아 해당 HabitCheck 를 삭제하도록 변경하였습니다.
 
[fix(Service) : HabitService habitUnCheck 메소드 수정](https://github.com/potenday-project/Habiters_BE/commit/adfe847ea456d3394d43afecf2ae2687df7f1a66) 
- HabitCheck 를 삭제할 때 기존은 HabitId를 받은 후 HabitCheck 데이터를 삭제하도록 했었지만,
Habit 안에 HabitCheck 는 List 형태로 받아오기 떄문에 두개 이상의 데이터가 있을 경우
NonUniqueResultException 예외가 터지며, 정상적으로 메소드가 실행되지 않습니다.
- 해당 오류를 수정하기 위하여 HabitId 에서 HabitCheckId 를 변수로 받아 해당 HabitCheck 를 삭제하도록 변경하였습니다.


[fix(Test_Habit) : HabitServiceTest habitUnCheck 테스트 수정](https://github.com/potenday-project/Habiters_BE/commit/290641d85f01e76602022b9f5e5dde50126d33e0) 
- HabitUnCheck 의 메소드가 변경되어, 테스트 검증방법을 변경하였습니다.