### PR TITLE
[#49] Feat : member profile 업데이트 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt:0.9.1'
     implementation 'javax.xml.bind:jaxb-api:2.3.0'
     implementation 'com.mysql:mysql-connector-j:8.0.32'
+    implementation 'com.amazonaws:aws-java-sdk-s3:1.12.429'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/clover/habbittracker/domain/member/api/MemberController.java
+++ b/src/main/java/com/clover/habbittracker/domain/member/api/MemberController.java
@@ -3,19 +3,22 @@ package com.clover.habbittracker.domain.member.api;
 import static com.clover.habbittracker.global.dto.ResponseType.*;
 
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 import com.clover.habbittracker.domain.member.dto.MemberRequest;
 import com.clover.habbittracker.domain.member.dto.MemberResponse;
 import com.clover.habbittracker.domain.member.service.MemberService;
 import com.clover.habbittracker.global.dto.BaseResponse;
+import com.clover.habbittracker.ncp.ObjectStorageService;
 
 import lombok.RequiredArgsConstructor;
 
@@ -26,6 +29,8 @@ public class MemberController {
 
 	private final MemberService memberService;
 
+	private final ObjectStorageService objectStorageService;
+
 	@GetMapping("/me")
 	ResponseEntity<BaseResponse<MemberResponse>> getMyProfile(@AuthenticationPrincipal Long memberId) {
 		MemberResponse profile = memberService.getProfile(memberId);
@@ -33,9 +38,12 @@ public class MemberController {
 		return ResponseEntity.ok().body(response);
 	}
 
-	@PutMapping("/me")
+	@PutMapping(path = "/me",consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
 	ResponseEntity<BaseResponse<MemberResponse>> updateMyProfile(@AuthenticationPrincipal Long memberId,
-																 @RequestBody MemberRequest request) {
+		MemberRequest request,
+		@RequestPart MultipartFile file) {
+		String profileImgUrl = objectStorageService.profileImgSave(file);
+		request.setProfileImgUrl(profileImgUrl);
 		MemberResponse updateProfile = memberService.updateProfile(memberId, request);
 		BaseResponse<MemberResponse> response = BaseResponse.of(updateProfile, MEMBER_UPDATE);
 		return ResponseEntity.ok().body(response);

--- a/src/main/java/com/clover/habbittracker/domain/member/dto/MemberRequest.java
+++ b/src/main/java/com/clover/habbittracker/domain/member/dto/MemberRequest.java
@@ -2,9 +2,11 @@ package com.clover.habbittracker.domain.member.dto;
 
 import lombok.Builder;
 import lombok.Getter;
+import lombok.Setter;
 
 @Builder
 @Getter
+@Setter
 public class MemberRequest {
 	String nickName;
 	String profileImgUrl;

--- a/src/main/java/com/clover/habbittracker/ncp/ObjectStorageService.java
+++ b/src/main/java/com/clover/habbittracker/ncp/ObjectStorageService.java
@@ -1,0 +1,65 @@
+package com.clover.habbittracker.ncp;
+
+import java.io.File;
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Slf4j
+public class ObjectStorageService {
+
+	private final AmazonS3 objectStorage;
+	private final String imgPath;
+
+	public ObjectStorageService(AmazonS3 objectStorage) {
+		this.objectStorage = objectStorage;
+		this.imgPath = System.getProperty("user.dir") + "/tmp";
+	}
+
+	public String profileImgSave(MultipartFile file) {
+		if (file == null)
+			return null;
+
+		String buketName = "user-profile-image";
+		String fileName = tempFileSave(file);
+		PutObjectRequest request = new PutObjectRequest(buketName, fileName, new File(imgPath, fileName));
+		request.withCannedAcl(CannedAccessControlList.PublicRead);
+		objectStorage.putObject(request);
+
+		if (!tempFileDelete(fileName)) {
+			log.error("Failed to delete file. The administrator should check it out");
+		}
+
+		return objectStorage.getUrl(buketName, fileName).toString();
+	}
+
+	protected boolean tempFileDelete(String fileName) {
+		File tempFile = new File(imgPath, fileName);
+		if (tempFile.exists()) {
+			return tempFile.delete();
+		}
+		return false;
+	}
+
+	protected String tempFileSave(MultipartFile file) {
+		String uuid = UUID.randomUUID().toString().substring(0, 8);
+
+		String imgName = uuid + "_" + file.getOriginalFilename();
+		File imgFile = new File(imgPath, imgName);
+		try {
+			file.transferTo(imgFile);
+		} catch (Exception e) {
+			System.out.println(e.getMessage());
+		}
+
+		return imgName;
+	}
+}

--- a/src/main/java/com/clover/habbittracker/ncp/config/NcpConfig.java
+++ b/src/main/java/com/clover/habbittracker/ncp/config/NcpConfig.java
@@ -1,0 +1,35 @@
+package com.clover.habbittracker.ncp.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+
+@Configuration
+public class NcpConfig {
+	private final String endPoint;
+	private final String regionName;
+	private final String accessKey;
+	private final String secretKey;
+
+	public NcpConfig(@Value("${NCP_API_ACCESS_KEY}") String accessKey,
+		@Value("${NCP_SECRET_KEY}") String secretKey) {
+		this.endPoint = "https://kr.object.ncloudstorage.com";
+		this.regionName = "kr-standard";
+		this.accessKey = accessKey;
+		this.secretKey = secretKey;
+	}
+
+	@Bean
+	public AmazonS3 NcpStorageServer() {
+		return AmazonS3ClientBuilder.standard()
+			.withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(endPoint, regionName))
+			.withCredentials(new AWSStaticCredentialsProvider(new BasicAWSCredentials(accessKey, secretKey)))
+			.build();
+	}
+}

--- a/src/test/java/com/clover/habbittracker/domain/member/api/MemberControllerTest.java
+++ b/src/test/java/com/clover/habbittracker/domain/member/api/MemberControllerTest.java
@@ -4,12 +4,14 @@ import static com.clover.habbittracker.global.util.ApiDocumentUtils.*;
 import static com.clover.habbittracker.global.util.MemberProvider.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.hamcrest.core.Is.*;
+import static org.mockito.Mockito.*;
 import static org.springframework.http.MediaType.*;
 import static org.springframework.restdocs.headers.HeaderDocumentation.*;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
 import static org.springframework.restdocs.payload.JsonFieldType.STRING;
 import static org.springframework.restdocs.payload.JsonFieldType.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -20,14 +22,17 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpMethod;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.clover.habbittracker.domain.member.dto.MemberRequest;
 import com.clover.habbittracker.domain.member.entity.Member;
 import com.clover.habbittracker.domain.member.repository.MemberRepository;
 import com.clover.habbittracker.global.security.jwt.JwtProvider;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.clover.habbittracker.ncp.ObjectStorageService;
 
 @SpringBootTest(properties = {"spring.datasource.url=jdbc:h2:mem:testdb",
 	"spring.datasource.driver-class-name=org.h2.Driver", "spring.datasource.username=sa",
@@ -42,6 +47,9 @@ public class MemberControllerTest {
 	private JwtProvider jwtProvider;
 	@Autowired
 	private MemberRepository memberRepository;
+
+	@MockBean
+	private ObjectStorageService objectStorageService;
 
 	private String accessJwt;
 
@@ -79,22 +87,25 @@ public class MemberControllerTest {
 				)
 			));
 	}
-
 	@Test
 	@DisplayName("사용자는 자신의 프로필 닉네임과 프로필 이미지를 바꿀수있다.")
 	void updateMyProfileTest() throws Exception {
 		//given
-		MemberRequest memberRequest = MemberRequest.builder()
-			.nickName("updateNickName")
-			.profileImgUrl("updateProfileImgUrl")
-			.build();
-		String request = new ObjectMapper().writeValueAsString(memberRequest);
+		String mockProfileImgUrl = "updateProfileImgUrl";
+		when(objectStorageService.profileImgSave(any())).thenReturn(mockProfileImgUrl);
+
+		MockMultipartFile mockFile = new MockMultipartFile("file", "test.jpg", "image/jpeg", new byte[0]);
 
 		//when then
-		mockMvc.perform(put("/users/me")
+		mockMvc.perform(RestDocumentationRequestBuilders.multipart("/users/me")
+				.file(mockFile)
 				.header("Authorization", "Bearer " + accessJwt)
-				.contentType(APPLICATION_JSON)
-				.content(request))
+				.content(MULTIPART_FORM_DATA_VALUE)
+				.param("nickName","updateNickName")
+				.with(request -> {
+					request.setMethod(HttpMethod.PUT.name());
+					return request;
+				}))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.data.nickName", is("updateNickName")))
 			.andExpect(jsonPath("$.data.profileImgUrl", is("updateProfileImgUrl")))
@@ -104,9 +115,11 @@ public class MemberControllerTest {
 				requestHeaders(
 					headerWithName("Authorization").description("JWT Access 토큰")
 				),
-				requestFields(
-					fieldWithPath("nickName").description("수정할 닉네임"),
-					fieldWithPath("profileImgUrl").description("수정할 프로필 사진 URL")
+				requestParts(
+					partWithName("file").description("업데이트할 파일")
+				),
+				queryParameters(
+					parameterWithName("nickName").description("수정할 닉네임")
 				),
 				responseFields(
 					fieldWithPath("code").type(STRING).description("결과 코드"),
@@ -118,21 +131,25 @@ public class MemberControllerTest {
 				)
 			));
 	}
-
 	@Test
 	@DisplayName("기존의 사용하고 있는 닉네임은 중복으로 생각하여 예외가 발생한다.")
 	void updateNickNameDuplicateTest() throws Exception {
 		//given
-		MemberRequest memberRequest = MemberRequest.builder()
-			.nickName("testNickName")
-			.build();
-		String request = new ObjectMapper().writeValueAsString(memberRequest);
+		String mockProfileImgUrl = "updateProfileImgUrl";
+		when(objectStorageService.profileImgSave(any())).thenReturn(mockProfileImgUrl);
+
+		MockMultipartFile mockFile = new MockMultipartFile("file", "test.jpg", "image/jpeg", new byte[0]);
 
 		//when then
-		mockMvc.perform(put("/users/me")
+		mockMvc.perform(RestDocumentationRequestBuilders.multipart("/users/me")
+				.file(mockFile)
 				.header("Authorization", "Bearer " + accessJwt)
-				.contentType(APPLICATION_JSON)
-				.content(request))
+				.content(MULTIPART_FORM_DATA_VALUE)
+				.param("nickName","testNickName")
+				.with(request -> {
+					request.setMethod(HttpMethod.PUT.name());
+					return request;
+				}))
 			.andExpect(
 				result -> assertThat(result.getResolvedException()).isInstanceOf(IllegalArgumentException.class))
 			.andDo(document("duplicate-member",

--- a/src/test/java/com/clover/habbittracker/ncp/ObjectStorageServiceTest.java
+++ b/src/test/java/com/clover/habbittracker/ncp/ObjectStorageServiceTest.java
@@ -1,0 +1,64 @@
+package com.clover.habbittracker.ncp;
+
+import static org.mockito.Mockito.*;
+
+import java.io.IOException;
+import java.net.URL;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+
+public class ObjectStorageServiceTest {
+	private ObjectStorageService objectStorageService;
+
+	@Mock
+	private AmazonS3 mockStorage;
+
+	@BeforeEach
+	public void setup() {
+		MockitoAnnotations.openMocks(this);
+		objectStorageService = new ObjectStorageService(mockStorage);
+	}
+
+	@Test
+	@DisplayName("multipartForm 데이터가 요청되었을때, 스토리지 서버에 저장한 후 파일이 저장된 url을 받는다.")
+	public void naverCloudProfileImgSaveTest() throws IOException {
+		//given
+		MultipartFile mockFile = new MockMultipartFile("test.jpg", "test.jpg", "image/jpeg", new byte[0]);
+		String expectedBucketName = "user-profile-image";
+		String mockUrl = "http://simple.url";
+
+		//when
+		when(mockStorage.putObject(any(PutObjectRequest.class))).thenReturn(null);
+		when(mockStorage.getUrl(anyString(),anyString())).thenReturn(new URL(mockUrl));
+		String result = objectStorageService.profileImgSave(mockFile);
+
+		//then
+		Assertions.assertThat(result).isEqualTo(mockUrl);
+		verify(mockStorage).getUrl(eq(expectedBucketName),anyString());
+	}
+
+	@Test
+	@DisplayName("multipartForm 데이터가 없다면 예외처리는 따로 하지않고, null을 반환한다.")
+	public void failedProfileImgSaveTest() throws IOException {
+		//given
+		String mockUrl = "http://simple.url";
+
+		//when
+		when(mockStorage.putObject(any(PutObjectRequest.class))).thenReturn(null);
+		when(mockStorage.getUrl(anyString(),anyString())).thenReturn(new URL(mockUrl));
+		String result = objectStorageService.profileImgSave(null);
+
+		//then
+		Assertions.assertThat(result).isEqualTo(null);
+	}
+}


### PR DESCRIPTION
## 작업 사항

**회원 프로필 사진을 변경하기 위해 multipartFile 로 파일 데이터를 받은 후 네이버 클라우드 스토리지 서버에 이미지 파일을 저장합니다.
회원 테이블 profileUrl은 스토리지 서버에 저장되어 있는 사진의 url 로 변경됩니다.
Mockito 를 사용한 테스트를 처음 사용하다 보니 테스트 코드 작성에서 많이 오래 걸렸네요...
네이버 클라우드의 서비스를 더 연동 할 수 도 있기떄문에, 패키지를 따로 나누어 api 키와 secret 키로 설정하는 설정 클래스를 생성하였습니다.**

[config(gradle) : AmazonS3 라이브러리 의존성 추가](https://github.com/potenday-project/Habiters_BE/commit/6ce9d1f25b049184b6ef82474c2a4b699b4e9c54) 
- 스토리지 서버 연동을 위해 AmazonS3 라이브러리를 추가하였습니다.
 
[feat(controller) : 프로필 사진 업데이트 추가](https://github.com/potenday-project/Habiters_BE/commit/9fd26aebf31d5601f9e25770d023507df91e274e) 
- 프로필 사진도 업데이트 하기위하여 매개변수로 MultipartFile 을 추가하였습니다.
- 파일은 ObjectStorageService 로 스토리지 서버에 저장 후 저장된 url 정보를 받아와 request dto 내에 정보를 변경하여 전체적으로 업데이트를 진행하도록 구성했습니다.
- 파일이 존재하지 않을 경우 null 로 처리되어, 업데이트 되지않습니다.
 
[chore(dto) : MemberRequest Setter 추가](https://github.com/potenday-project/Habiters_BE/commit/06e387f19d78d722e8932af2a4e41ca2c3ddb8f3) 
- 프로필 이미지의 url 을 수정하기 위해 setter 를 추가하였습니다.
 
[feat(ncp): 네이버 클라우드 플랫폼 설정 클래스 추가](https://github.com/potenday-project/Habiters_BE/commit/53dd12b38e2e946b786c61572d7feb6a8b6d6350) 
- 네이버 클라우드 플랫폼 내 스토리지 서버 설정을 추가하기 위해 NcpConfig 클래스를 작성하였습니다.
- 제공된 액세스 키와 비밀 키를 사용하여 StorageServer 구성을 구현하였습니다.
 
[feat(ncp): 네이버 클라우드 플랫폼을 위한 ObjectStorageService 추가](https://github.com/potenday-project/Habiters_BE/commit/da3fe9c65635ce4c291cef83f4d067fd08d7a067) 
- ObjectStorageService 클래스를 구현하여 네이버 클라우드 플랫폼에 파일 저장 및 검색 기능을 처리하도록 하였습니다.
- 해당 서비스는 AmazonS3를 사용하여 스토리지 서버와 상호 작용합니다.
- profileImgSave 메서드는 제공된 MultipartFile 을 프로필 이미지 파일로 저장합니다.
- UUID 와 원본 파일 이름을 사용하여 임시 파일을 로컬에 저장합니다.
- UUID 의 내용이 너무 길다 생각하여 앞에 8글자만 사용하는것으로 했습니다.
- 저장된 파일은 네이버 클라우드 플랫폼의 "user-profile-image" 버킷에 업로드됩니다.
- 파일은 공개 읽기 권한이 부여됩니다.
- 업로드가 성공하면 임시 파일이 삭제됩니다.
- 업로드된 파일의 URL이 결과로 반환됩니다.
 
[feat(Test_ncp): ObjectStorageService 테스트 추가](https://github.com/potenday-project/Habiters_BE/commit/b39e1ed14f0d5a5edc3eede92b858330277d2535) 
- ObjectStorageService 클래스에 대한 테스트를 추가하였습니다.
- 스토리지 서버와 상호 작용하기 위해 AmazonS3를 가상화한 mockStorage를 사용합니다.
- Mockito를 사용하여 mock 객체를 초기화하고, ObjectStorageService를 생성합니다.
- "multipartForm 데이터가 요청되었을 때, 스토리지 서버에 저장한 후 파일이 저장된 URL을 받는다"라는 테스트를 작성하였습니다.
- MockMultipartFile을 사용하여 테스트용 파일을 생성합니다.
- 예상되는 버킷 이름은 "user-profile-image"입니다.
- mockStorage의 putObject() 메서드와 getUrl() 메서드의 동작을 설정하고, ObjectStorageService의 profileImgSave() 메서드를 호출하여 결과를 검증합니다.
- 결과 URL이 예상한 URL과 일치하는지 확인합니다.
- getUrl() 메서드 호출이 예상된 버킷 이름과 파일 이름으로 수행되었는지 검증합니다.
- "multipartForm 데이터가 없다면 예외 처리는 따로 하지 않고, null을 반환한다"라는 테스트를 작성하였습니다.
- profileImgSave() 메서드에 null을 전달하여 호출하고, null이 반환되는지 확인합니다.

 
[chore(Test_Controller): MemberControllerTest 테스트 수정](https://github.com/potenday-project/Habiters_BE/commit/3d9efb77a71d642f466377c6f76a61aae3669fe1) 
- 기존 파일 없이 간단하게 하던 테스트에서 직접 파일을 받아 저장하는 테스트로 변경하였습니다.
- MockMultipartFile 로 가짜 파일을 만들어 테스트 하였습니다.
- 또한, 실제로 스토리지 서버에 테스트 할 때마다 파일을 올릴수 없기에 objectStorage 를 Mock 객체로 생성하여, 간단하게 url을 반환하도록 설정하여 테스트를 진행했습니다.
- multipart 를 mockMvc 로 테스트 할 경우 기본으로 설정되어 있는 메소드는 post 이므로, with 을 사용하여 request 에 put 메소드를 추가하여 리턴하는 람다식을 추가하였습니다.
- 더 이상 바디에 데이터를 담지 않고, parameter 로 값을 받기떄문에 수정하였습니다.