### PR TITLE
[#49] Fix : 회원 프로필 사진 업데이트 수정

### DIFF
--- a/src/main/java/com/clover/habbittracker/domain/member/api/MemberController.java
+++ b/src/main/java/com/clover/habbittracker/domain/member/api/MemberController.java
@@ -41,7 +41,7 @@ public class MemberController {
 	@PutMapping(path = "/me",consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
 	ResponseEntity<BaseResponse<MemberResponse>> updateMyProfile(@AuthenticationPrincipal Long memberId,
 		MemberRequest request,
-		@RequestPart MultipartFile file) {
+		@RequestPart(required = false) MultipartFile file) {
 		String profileImgUrl = objectStorageService.profileImgSave(file);
 		request.setProfileImgUrl(profileImgUrl);
 		MemberResponse updateProfile = memberService.updateProfile(memberId, request);

--- a/src/test/java/com/clover/habbittracker/domain/member/api/MemberControllerTest.java
+++ b/src/test/java/com/clover/habbittracker/domain/member/api/MemberControllerTest.java
@@ -163,7 +163,80 @@ public class MemberControllerTest {
 					fieldWithPath("msg").type(STRING).description("결과 메시지")
 				)));
 	}
+	@Test
+	@DisplayName("사용자는 자신의 프로필 닉네임만 변경할 수 있다.")
+	void updateMyProfileNickNameTest() throws Exception {
+		//when then
+		mockMvc.perform(RestDocumentationRequestBuilders.multipart("/users/me")
+				.header("Authorization", "Bearer " + accessJwt)
+				.content(MULTIPART_FORM_DATA_VALUE)
+				.param("nickName","updateNickName")
+				.with(request -> {
+					request.setMethod(HttpMethod.PUT.name());
+					return request;
+				}))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.nickName", is("updateNickName")))
+			.andExpect(jsonPath("$.data.profileImgUrl", is("testImgUrl")))
+			.andDo(document("member-update-nickName",
+				getDocumentRequest(),
+				getDocumentResponse(),
+				requestHeaders(
+					headerWithName("Authorization").description("JWT Access 토큰")
+				),
+				queryParameters(
+					parameterWithName("nickName").description("수정할 닉네임")
+				),
+				responseFields(
+					fieldWithPath("code").type(STRING).description("결과 코드"),
+					fieldWithPath("message").type(STRING).description("결과 메시지"),
+					fieldWithPath("data.id").type(NUMBER).description("회원 아이디"),
+					fieldWithPath("data.email").type(STRING).description("회원 이메일"),
+					fieldWithPath("data.nickName").type(STRING).description("회원 닉네임"),
+					fieldWithPath("data.profileImgUrl").type(STRING).description("회원 프로필 사진 URL")
+				)
+			));
+	}
+	@Test
+	@DisplayName("사용자는 자신의 프로필 이미지만 변경할 수 있다.")
+	void updateMyProfileImageTest() throws Exception {
+		//given
+		String mockProfileImgUrl = "updateProfileImgUrl";
+		when(objectStorageService.profileImgSave(any())).thenReturn(mockProfileImgUrl);
 
+		MockMultipartFile mockFile = new MockMultipartFile("file", "test.jpg", "image/jpeg", new byte[0]);
+
+		//when then
+		mockMvc.perform(RestDocumentationRequestBuilders.multipart("/users/me")
+				.file(mockFile)
+				.header("Authorization", "Bearer " + accessJwt)
+				.content(MULTIPART_FORM_DATA_VALUE)
+				.with(request -> {
+					request.setMethod(HttpMethod.PUT.name());
+					return request;
+				}))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.nickName", is("testNickName")))
+			.andExpect(jsonPath("$.data.profileImgUrl", is(mockProfileImgUrl)))
+			.andDo(document("member-update-Profile",
+				getDocumentRequest(),
+				getDocumentResponse(),
+				requestHeaders(
+					headerWithName("Authorization").description("JWT Access 토큰")
+				),
+				requestParts(
+					partWithName("file").description("업데이트할 파일")
+				),
+				responseFields(
+					fieldWithPath("code").type(STRING).description("결과 코드"),
+					fieldWithPath("message").type(STRING).description("결과 메시지"),
+					fieldWithPath("data.id").type(NUMBER).description("회원 아이디"),
+					fieldWithPath("data.email").type(STRING).description("회원 이메일"),
+					fieldWithPath("data.nickName").type(STRING).description("회원 닉네임"),
+					fieldWithPath("data.profileImgUrl").type(STRING).description("회원 프로필 사진 URL")
+				)
+			));
+	}
 	@Test
 	@DisplayName("사용자는 자신의 프로필 정보를 삭제 할 수 있다.")
 	void deleteProfileTest() throws Exception {


### PR DESCRIPTION
## 작업 사항 [#49]

**현재 회원이 업데이트를 하기 위해서 프로필 이미지 파일이 필수 값으로 설정 되어있어, 닉네임만 수정 할 수 없습니다.
따라서 해당 파일을 Null 의 값을 받을 수 있게 수정하여 회원이 업데이트 하고 싶은 것만 선택하여 변경 할 수 있도록 수정하였습니다.**

_**ps) 현재 파일 업로드 부분은 따로 빼서 관리하도록 변경할 예정이였으나, 기획이 변경되어, 추후 프로필 사진은 삭제 될 수 있습니다.
해당 수정 내용은 아직 기획이 확정 되지 않아, 버그를 수정하기 위한 작업 내용입니다.**_

---

[fix(Member): 회원 프로필 사진 옵션 값 변경](https://github.com/potenday-project/Habiters_BE/commit/726a1bd8e4ec04865c19888f8d2a7c694bc706bf) 
- 현재는 프로필 이미지 파일이 필수값으로 되어있습니다.
- 하지만 회원은 프로필 사진만 변경할수도 있고, 닉네임만 변경 할 수도 있어야 하기 떄문에, MultiPartFile 을 Required 를 false 로 변경하여, 옵션으로 받을수 있도록 변경하였습니다.
 
[fix(Test_Member): 회원 프로필 업데이트 테스트 추가](https://github.com/potenday-project/Habiters_BE/commit/9b22b50997dcca6a8d8386b98e82e312f2112fc0) 
- 프로필을 업데이트 할 경우,회원이 프로필을 수정하기 위해 입력 한 값만 변경하는 것을 테스트 하였습니다.