### PR TITLE
[#52] Fix: 회고록 최신순으로 조회하도록 수정

### DIFF
--- a/src/main/java/com/clover/habbittracker/domain/diary/repository/DiaryRepository.java
+++ b/src/main/java/com/clover/habbittracker/domain/diary/repository/DiaryRepository.java
@@ -15,6 +15,7 @@ public interface DiaryRepository extends JpaRepository<Diary,Long> {
 			FROM Diary d
 			WHERE d.member.id = :memberId
 			AND d.createdAt BETWEEN :start AND :end
+			ORDER BY d.createdAt DESC
 		""")
 	List<Diary> findByMemberId(@Param("memberId") Long memberId, @Param("start") LocalDateTime start, @Param("end") LocalDateTime end);
 

--- a/src/test/java/com/clover/habbittracker/domain/diary/repository/DiaryRepositoryTest.java
+++ b/src/test/java/com/clover/habbittracker/domain/diary/repository/DiaryRepositoryTest.java
@@ -82,7 +82,7 @@ public class DiaryRepositoryTest {
 	}
 
 	@Test
-	@DisplayName("사용자의 월별 회고록 리스트를 조회 할 수 있다.")
+	@DisplayName("사용자의 월별 회고록 리스트를 최신순으로 조회 할 수 있다.")
 	void findByMemberIdDateBetweenTest() {
 		//given
 		for (int i = 0; i < 10; i++) {
@@ -100,10 +100,16 @@ public class DiaryRepositoryTest {
 		//then
 		assertThat(diaryList1.size()).isEqualTo(10);
 		assertThat(diaryList2.size()).isEqualTo(0);
-		diaryList1.forEach(
-			diary -> assertThat(diary)
+		LocalDateTime previousDate = null;
+		for (Diary diary : diaryList1) {
+			assertThat(diary)
 				.hasFieldOrProperty("id")
-				.hasFieldOrProperty("content"));
+				.hasFieldOrProperty("content");
+			if (previousDate != null) {
+				assertThat(diary.getCreatedAt()).isBeforeOrEqualTo(previousDate);
+			}
+			previousDate = diary.getCreatedAt();
+		}
 	}
 
 }


### PR DESCRIPTION
### 작업사항[#52]

[fix(Diary): 회고록 조회시 최신 순으로 변경](https://github.com/potenday-project/Habiters_BE/commit/9ba144110546acdd3298b91e75744df473ed3e9b) 
- 회고록을 조회 시 최신순으로 정렬하기 위해 생성날짜를 기준으로 내림차순 정렬로 변경하였습니다.
 
[fix(Test_Diary): 회고록 조회시 최신순으로 변경](https://github.com/potenday-project/Habiters_BE/commit/718a2ab1bcc9df22ad578d011d6456d539b15bb8) 
- 회고록을 조회 할 경우 최신순으로 정렬되었는지 검증하는 부분을 추가하였습니다.