### PR TITLE
[#34]Fix: RestDocs 문서 수정 및 배포시 문서 접근이 불가능한 오류 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -94,17 +94,16 @@ asciidoctor.doFirst {
 
 bootJar {
     dependsOn asciidoctor
-    copy {
-        from "${asciidoctor.outputDir}"
-        into 'BOOT-INF/classes/static/docs'
+    from("${asciidoctor.outputDir}") {
+        into "static/docs"
     }
 
 }
 
 task copyDocument(type: Copy) {
     dependsOn asciidoctor
-    from file("build/docs/asciidoc")
-    into file("src/main/resources/static/docs")
+    from file("${asciidoctor.outputDir}")
+    into file("build/resources/main/static")
 }
 
 build {

--- a/src/docs/asciidoc/Error.adoc
+++ b/src/docs/asciidoc/Error.adoc
@@ -1,0 +1,34 @@
+[[Error]]
+== 에러
+
+=== 공통
+
+==== Response
+
+include::{snippets}/expired-diary/response-fields.adoc[]
+
+---
+
+=== 회고록 수정은 24시간 내에만 가능합니다.
+
+==== Response HTTP Example
+
+include::{snippets}/expired-diary/http-response.adoc[]
+
+=== 습관은 당일날만 체크 가능합니다.
+
+==== Response HTTP Example
+
+include::{snippets}/Expired-HabitCheck/http-response.adoc[]
+
+=== 습관체크를 중복 체크 할 수는 없습니다.
+
+==== Response HTTP Example
+
+include::{snippets}/Duplicate-HabitCheck/http-response.adoc[]
+
+=== 회원 닉네임은 중복이 될 수 없습니다.
+
+==== Response HTTP Example
+
+include::{snippets}/duplicate-member/http-response.adoc[]

--- a/src/docs/asciidoc/Member-API.adoc
+++ b/src/docs/asciidoc/Member-API.adoc
@@ -57,19 +57,3 @@ include::{snippets}/member-delete/http-request.adoc[]
 
 include::{snippets}/member-delete/http-response.adoc[]
 
-
-=== 에러
-
-==== Request
-
-===== Request HTTP Example
-
-include::{snippets}/duplicate-member/http-request.adoc[]
-
-==== Response
-
-include::{snippets}/duplicate-member/response-fields.adoc[]
-
-===== Response HTTP Example
-
-include::{snippets}/duplicate-member/http-response.adoc[]

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -14,3 +14,5 @@ include::Member-API.adoc[]
 include::Habit-API.adoc[]
 
 include::Diray-API.adoc[]
+
+include::Error.adoc[]

--- a/src/test/java/com/clover/habbittracker/domain/diary/api/DiaryControllerTest.java
+++ b/src/test/java/com/clover/habbittracker/domain/diary/api/DiaryControllerTest.java
@@ -174,7 +174,7 @@ public class DiaryControllerTest {
 					headerWithName("Authorization").description("JWT Access 토큰")
 				),
 				queryParameters(
-					parameterWithName("date").description("조회하고 싶은 연 월")
+					parameterWithName("date").description("조회하고 싶은 연 월").optional()
 				),
 				responseFields(
 					fieldWithPath("code").type(STRING).description("결과 코드"),

--- a/src/test/java/com/clover/habbittracker/domain/member/api/MemberControllerTest.java
+++ b/src/test/java/com/clover/habbittracker/domain/member/api/MemberControllerTest.java
@@ -116,10 +116,10 @@ public class MemberControllerTest {
 					headerWithName("Authorization").description("JWT Access 토큰")
 				),
 				requestParts(
-					partWithName("file").description("업데이트할 파일")
+					partWithName("file").description("업데이트할 파일").optional()
 				),
 				queryParameters(
-					parameterWithName("nickName").description("수정할 닉네임")
+					parameterWithName("nickName").description("수정할 닉네임").optional()
 				),
 				responseFields(
 					fieldWithPath("code").type(STRING).description("결과 코드"),
@@ -185,7 +185,7 @@ public class MemberControllerTest {
 					headerWithName("Authorization").description("JWT Access 토큰")
 				),
 				queryParameters(
-					parameterWithName("nickName").description("수정할 닉네임")
+					parameterWithName("nickName").description("수정할 닉네임").optional()
 				),
 				responseFields(
 					fieldWithPath("code").type(STRING).description("결과 코드"),
@@ -225,7 +225,7 @@ public class MemberControllerTest {
 					headerWithName("Authorization").description("JWT Access 토큰")
 				),
 				requestParts(
-					partWithName("file").description("업데이트할 파일")
+					partWithName("file").description("업데이트할 파일").optional()
 				),
 				responseFields(
 					fieldWithPath("code").type(STRING).description("결과 코드"),

--- a/src/test/resources/org/springframework/restdocs/templates/query-parameters.snippet
+++ b/src/test/resources/org/springframework/restdocs/templates/query-parameters.snippet
@@ -1,5 +1,4 @@
-===== Path Parameters
-
+===== query Parameters
 |===
 |경로 변수|필수값|설명
 

--- a/src/test/resources/org/springframework/restdocs/templates/request-fields.snippet
+++ b/src/test/resources/org/springframework/restdocs/templates/request-fields.snippet
@@ -5,7 +5,10 @@
 {{#fields}}
 	|{{#tableCellContent}}`+{{path}}+`{{/tableCellContent}}
 	|{{#tableCellContent}}`+{{type}}+`{{/tableCellContent}}
-	|{{#tableCellContent}}{{^optional}}true{{/optional}}{{/tableCellContent}}
+	|{{#tableCellContent}}
+		{{^optional}}true{{/optional}}
+		{{#optional}}false{{/optional}}
+	{{/tableCellContent}}
 	|{{#tableCellContent}}{{description}}{{/tableCellContent}}
 {{/fields}}
 |===

--- a/src/test/resources/org/springframework/restdocs/templates/request-parameters.snippet
+++ b/src/test/resources/org/springframework/restdocs/templates/request-parameters.snippet
@@ -5,7 +5,10 @@
 
 {{#parameters}}
 |{{#tableCellContent}}`+{{name}}+`{{/tableCellContent}}
-|{{#tableCellContent}}{{^optional}}true{{/optional}}{{/tableCellContent}}
+|{{#tableCellContent}}
+	{{^optional}}true{{/optional}}
+	{{#optional}}false{{/optional}}
+{{/tableCellContent}}
 |{{#tableCellContent}}{{description}}{{/tableCellContent}}
 
 {{/parameters}}


### PR DESCRIPTION
## 작업 사항 [#34]

[fix(Test): RestDocs 옵션 값 추가](https://github.com/potenday-project/Habiters_BE/commit/3a82ba822ecc94750f73076ef5d83dc14735a673) 
- 옵션으로 필요한 값을 .option() 을 추가하여 구분하였습니다.
 
[feat(restDocs) : Adoc 에러 추가](https://github.com/potenday-project/Habiters_BE/commit/f76ad3eb7b706441f95033c7da176df4b89eaeed) 
- API 에서 발생 할 수 있는 에러 내용을 추가하였습니다.
 
[feat(restDocs) : Adoc 에러 추가](https://github.com/potenday-project/Habiters_BE/commit/91ba55693fe7b522865219a970992091f2d3ec39) 
- API 에서 발생 할 수 있는 에러 내용을 추가하였습니다.
 
[chore(restDocs) : 에러 내용 삭제](https://github.com/potenday-project/Habiters_BE/commit/8cce48f609c136c71a7b4d8f571612d8a9696fd1) 
- 에러 내용은 Error.adoc 으로 관리함에 따라 에러 내용을 삭제하였습니다.
 
[chore(restDocs) : 필수값 여부 수정](https://github.com/potenday-project/Habiters_BE/commit/6dc71263e8d5cf427843dc46d2352f41bdb1ea81) 
- 기존은 필수값이 아니라면 아무런 표기가 되지않았지만, 좀 더 명확하게 알아볼수있도록 필수값이 아닐경우 false 로 표기하도록 변경하였습니다.
 
[config : gradle Restdocs 수정](https://github.com/potenday-project/Habiters_BE/commit/25ec3504dd0e23f679848f28068fabd55a5a5b11) 
- gradle task 중 build 시 processResources task 가 실행되며, 해당 task 는 프로젝트의 리소스 파일을 빌드된 결과물에 포함시키는 역할을 합니다.
- 따라서 processResources task 가 실행 되기전 Test 가 실행되어, RestDocs 문서를 만든 후 리소스를 빌드 결과물에 포함시켜야 합니다.
- 따라서 기존처럼 BOOT-INF/classes 를 복사하고자 하면, BOOT-INF 는 RestDocs 가 생성되지 않았기에 복사를 할 RestDocs 파일이 존재하지 않아 정상적으로 배포 되지 않습니다.
- 이 부분은 static/docs 를 복사 하는것으로 변경하였습니다
- 또한, 기존은 /docs/index.html 로 접근해야하지만, 해당 서버를 호출 했을때 404를 보여주는것이 아닌 api 문서를 바로 보여주기 위해 copyDocument 를 수정하였습니다.