### PR TITLE
[#55] Delete : 회원 프로필 수정 기능 삭제

### DIFF
--- a/src/main/java/com/clover/habbittracker/domain/member/api/MemberController.java
+++ b/src/main/java/com/clover/habbittracker/domain/member/api/MemberController.java
@@ -3,22 +3,19 @@ package com.clover.habbittracker.domain.member.api;
 import static com.clover.habbittracker.global.dto.ResponseType.*;
 
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.multipart.MultipartFile;
 
 import com.clover.habbittracker.domain.member.dto.MemberRequest;
 import com.clover.habbittracker.domain.member.dto.MemberResponse;
 import com.clover.habbittracker.domain.member.service.MemberService;
 import com.clover.habbittracker.global.dto.BaseResponse;
-import com.clover.habbittracker.ncp.ObjectStorageService;
 
 import lombok.RequiredArgsConstructor;
 
@@ -29,8 +26,6 @@ public class MemberController {
 
 	private final MemberService memberService;
 
-	private final ObjectStorageService objectStorageService;
-
 	@GetMapping("/me")
 	ResponseEntity<BaseResponse<MemberResponse>> getMyProfile(@AuthenticationPrincipal Long memberId) {
 		MemberResponse profile = memberService.getProfile(memberId);
@@ -38,12 +33,9 @@ public class MemberController {
 		return ResponseEntity.ok().body(response);
 	}
 
-	@PutMapping(path = "/me",consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
+	@PutMapping("/me")
 	ResponseEntity<BaseResponse<MemberResponse>> updateMyProfile(@AuthenticationPrincipal Long memberId,
-		MemberRequest request,
-		@RequestPart(required = false) MultipartFile file) {
-		String profileImgUrl = objectStorageService.profileImgSave(file);
-		request.setProfileImgUrl(profileImgUrl);
+		@RequestBody MemberRequest request) {
 		MemberResponse updateProfile = memberService.updateProfile(memberId, request);
 		BaseResponse<MemberResponse> response = BaseResponse.of(updateProfile, MEMBER_UPDATE);
 		return ResponseEntity.ok().body(response);

--- a/src/main/java/com/clover/habbittracker/domain/member/dto/MemberRequest.java
+++ b/src/main/java/com/clover/habbittracker/domain/member/dto/MemberRequest.java
@@ -1,13 +1,12 @@
 package com.clover.habbittracker.domain.member.dto;
 
-import lombok.Builder;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.Setter;
+import lombok.NoArgsConstructor;
 
-@Builder
 @Getter
-@Setter
+@NoArgsConstructor
+@AllArgsConstructor
 public class MemberRequest {
 	String nickName;
-	String profileImgUrl;
 }

--- a/src/main/java/com/clover/habbittracker/domain/member/dto/ProfileImg.java
+++ b/src/main/java/com/clover/habbittracker/domain/member/dto/ProfileImg.java
@@ -1,0 +1,23 @@
+package com.clover.habbittracker.domain.member.dto;
+
+import java.util.Random;
+
+import lombok.Getter;
+
+@Getter
+public enum ProfileImg {
+
+	HABITEE_LUCKY("https://kr.object.ncloudstorage.com/user-profile-image/Habitee_Lucky.png"),
+	HABITEE_HOPE("https://kr.object.ncloudstorage.com/user-profile-image/Habitee_Hope.png"),
+	HABITEE_DREAM("https://kr.object.ncloudstorage.com/user-profile-image/Habitee_Dream.png");
+
+	private final String imgUrl;
+
+	ProfileImg(String imgUrl) {
+		this.imgUrl = imgUrl;
+	}
+
+	public static ProfileImg getRandProfileImg() {
+		return values()[new Random().nextInt(values().length)];
+	}
+}

--- a/src/main/java/com/clover/habbittracker/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/clover/habbittracker/domain/member/service/MemberServiceImpl.java
@@ -7,6 +7,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.clover.habbittracker.domain.member.dto.MemberRequest;
 import com.clover.habbittracker.domain.member.dto.MemberResponse;
+import com.clover.habbittracker.domain.member.dto.ProfileImg;
 import com.clover.habbittracker.domain.member.entity.Member;
 import com.clover.habbittracker.domain.member.exception.MemberNotFoundException;
 import com.clover.habbittracker.domain.member.repository.MemberRepository;
@@ -55,14 +56,13 @@ public class MemberServiceImpl implements MemberService {
 				.oauthId(socialUser.getOauthId())
 				.nickName("해빗터_" + socialUser.getNickName())
 				.provider(socialUser.getProvider())
-				.profileImgUrl(socialUser.getProfileImgUrl())
+				.profileImgUrl(ProfileImg.getRandProfileImg().getImgUrl())
 				.build());
 	}
 
 	private Member update(Member member, MemberRequest request) {
 		Optional<Member> byNickName = memberRepository.findByNickName(request.getNickName());
 		if (byNickName.isEmpty()) {
-			Optional.ofNullable(request.getProfileImgUrl()).ifPresent(member::setProfileImgUrl);
 			Optional.ofNullable(request.getNickName()).ifPresent(member::setNickName);
 			return member;
 		} else {

--- a/src/main/java/com/clover/habbittracker/global/security/oauth/dto/GoogleUser.java
+++ b/src/main/java/com/clover/habbittracker/global/security/oauth/dto/GoogleUser.java
@@ -12,7 +12,6 @@ public class GoogleUser implements SocialUser{
 	String nickName;
 	String provider;
 	String oauthId;
-	String profileImgUrl;
 
 	@Override
 	public String getEmail() {
@@ -34,11 +33,6 @@ public class GoogleUser implements SocialUser{
 		return this.oauthId;
 	}
 
-	@Override
-	public String getProfileImgUrl() {
-		return this.profileImgUrl;
-	}
-
 	public static SocialUser info(OAuth2User oAuth2User) {
 		Map<String, Object> response = oAuth2User.getAttributes();
 
@@ -47,7 +41,6 @@ public class GoogleUser implements SocialUser{
 			.nickName(String.valueOf(response.get("name")))
 			.oauthId(String.valueOf(response.get("sub")))
 			.provider("google")
-			.profileImgUrl(String.valueOf(response.get("picture")))
 			.build();
 	}
 }

--- a/src/main/java/com/clover/habbittracker/global/security/oauth/dto/KakaoUser.java
+++ b/src/main/java/com/clover/habbittracker/global/security/oauth/dto/KakaoUser.java
@@ -12,7 +12,6 @@ public class KakaoUser implements SocialUser{
 	String nickName;
 	String provider;
 	String oauthId;
-	String profileImgUrl;
 
 	@Override
 	public String getEmail() {
@@ -34,10 +33,6 @@ public class KakaoUser implements SocialUser{
 		return this.oauthId;
 	}
 
-	@Override
-	public String getProfileImgUrl() {
-		return this.profileImgUrl;
-	}
 
 	public static SocialUser info(OAuth2User oAuth2User) {
 		Map<String, Object> response = oAuth2User.getAttributes();
@@ -49,7 +44,6 @@ public class KakaoUser implements SocialUser{
 			.nickName(String.valueOf(properties.get("nickname")))
 			.oauthId(String.valueOf(response.get("id")))
 			.provider("kakao")
-			.profileImgUrl(String.valueOf(properties.get("profile_image")))
 			.build();
 	}
 }

--- a/src/main/java/com/clover/habbittracker/global/security/oauth/dto/NaverUser.java
+++ b/src/main/java/com/clover/habbittracker/global/security/oauth/dto/NaverUser.java
@@ -12,7 +12,6 @@ public class NaverUser implements SocialUser {
 	String nickName;
 	String provider;
 	String oauthId;
-	String profileImgUrl;
 
 	@Override
 	public String getEmail() {
@@ -34,10 +33,6 @@ public class NaverUser implements SocialUser {
 		return this.oauthId;
 	}
 
-	@Override
-	public String getProfileImgUrl() {
-		return this.profileImgUrl;
-	}
 
 	public static SocialUser info(OAuth2User oAuth2User) {
 		Map<String, Object> response = oAuth2User.getAttribute("response");
@@ -47,7 +42,6 @@ public class NaverUser implements SocialUser {
 			.nickName(String.valueOf(response.get("name")))
 			.oauthId(String.valueOf(response.get("id")))
 			.provider("naver")
-			.profileImgUrl(String.valueOf(response.get("profile_image")))
 			.build();
 
 	}

--- a/src/main/java/com/clover/habbittracker/global/security/oauth/dto/SocialUser.java
+++ b/src/main/java/com/clover/habbittracker/global/security/oauth/dto/SocialUser.java
@@ -10,6 +10,6 @@ public interface SocialUser {
 	String getProvider();
 
 	String getOauthId();
-
-	String getProfileImgUrl();
+	//
+	// String getProfileImgUrl();
 }

--- a/src/main/java/com/clover/habbittracker/ncp/ObjectStorageService.java
+++ b/src/main/java/com/clover/habbittracker/ncp/ObjectStorageService.java
@@ -12,6 +12,9 @@ import com.amazonaws.services.s3.model.PutObjectRequest;
 
 import lombok.extern.slf4j.Slf4j;
 
+/* 2023/05/30 프로필 이미지를 사용하지 않기때문에 해당 서비스는 미사용
+** 추후 다시 사용 할 수 있음 **
+*/
 @Service
 @Slf4j
 public class ObjectStorageService {

--- a/src/test/java/com/clover/habbittracker/domain/member/api/MemberControllerTest.java
+++ b/src/test/java/com/clover/habbittracker/domain/member/api/MemberControllerTest.java
@@ -4,14 +4,12 @@ import static com.clover.habbittracker.global.util.ApiDocumentUtils.*;
 import static com.clover.habbittracker.global.util.MemberProvider.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.hamcrest.core.Is.*;
-import static org.mockito.Mockito.*;
 import static org.springframework.http.MediaType.*;
 import static org.springframework.restdocs.headers.HeaderDocumentation.*;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
 import static org.springframework.restdocs.payload.JsonFieldType.STRING;
 import static org.springframework.restdocs.payload.JsonFieldType.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
-import static org.springframework.restdocs.request.RequestDocumentation.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -22,17 +20,14 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.http.HttpMethod;
-import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.clover.habbittracker.domain.member.dto.MemberRequest;
 import com.clover.habbittracker.domain.member.entity.Member;
 import com.clover.habbittracker.domain.member.repository.MemberRepository;
 import com.clover.habbittracker.global.security.jwt.JwtProvider;
-import com.clover.habbittracker.ncp.ObjectStorageService;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 @SpringBootTest(properties = {"spring.datasource.url=jdbc:h2:mem:testdb",
 	"spring.datasource.driver-class-name=org.h2.Driver", "spring.datasource.username=sa",
@@ -47,9 +42,6 @@ public class MemberControllerTest {
 	private JwtProvider jwtProvider;
 	@Autowired
 	private MemberRepository memberRepository;
-
-	@MockBean
-	private ObjectStorageService objectStorageService;
 
 	private String accessJwt;
 
@@ -88,68 +80,16 @@ public class MemberControllerTest {
 			));
 	}
 	@Test
-	@DisplayName("사용자는 자신의 프로필 닉네임과 프로필 이미지를 바꿀수있다.")
-	void updateMyProfileTest() throws Exception {
-		//given
-		String mockProfileImgUrl = "updateProfileImgUrl";
-		when(objectStorageService.profileImgSave(any())).thenReturn(mockProfileImgUrl);
-
-		MockMultipartFile mockFile = new MockMultipartFile("file", "test.jpg", "image/jpeg", new byte[0]);
-
-		//when then
-		mockMvc.perform(RestDocumentationRequestBuilders.multipart("/users/me")
-				.file(mockFile)
-				.header("Authorization", "Bearer " + accessJwt)
-				.content(MULTIPART_FORM_DATA_VALUE)
-				.param("nickName","updateNickName")
-				.with(request -> {
-					request.setMethod(HttpMethod.PUT.name());
-					return request;
-				}))
-			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.data.nickName", is("updateNickName")))
-			.andExpect(jsonPath("$.data.profileImgUrl", is("updateProfileImgUrl")))
-			.andDo(document("member-update",
-				getDocumentRequest(),
-				getDocumentResponse(),
-				requestHeaders(
-					headerWithName("Authorization").description("JWT Access 토큰")
-				),
-				requestParts(
-					partWithName("file").description("업데이트할 파일")
-				),
-				queryParameters(
-					parameterWithName("nickName").description("수정할 닉네임")
-				),
-				responseFields(
-					fieldWithPath("code").type(STRING).description("결과 코드"),
-					fieldWithPath("message").type(STRING).description("결과 메시지"),
-					fieldWithPath("data.id").type(NUMBER).description("회원 아이디"),
-					fieldWithPath("data.email").type(STRING).description("회원 이메일"),
-					fieldWithPath("data.nickName").type(STRING).description("회원 닉네임"),
-					fieldWithPath("data.profileImgUrl").type(STRING).description("회원 프로필 사진 URL")
-				)
-			));
-	}
-	@Test
 	@DisplayName("기존의 사용하고 있는 닉네임은 중복으로 생각하여 예외가 발생한다.")
 	void updateNickNameDuplicateTest() throws Exception {
 		//given
-		String mockProfileImgUrl = "updateProfileImgUrl";
-		when(objectStorageService.profileImgSave(any())).thenReturn(mockProfileImgUrl);
-
-		MockMultipartFile mockFile = new MockMultipartFile("file", "test.jpg", "image/jpeg", new byte[0]);
+		String request = new ObjectMapper().writeValueAsString(new MemberRequest("testNickName"));
 
 		//when then
-		mockMvc.perform(RestDocumentationRequestBuilders.multipart("/users/me")
-				.file(mockFile)
+		mockMvc.perform(put("/users/me")
 				.header("Authorization", "Bearer " + accessJwt)
-				.content(MULTIPART_FORM_DATA_VALUE)
-				.param("nickName","testNickName")
-				.with(request -> {
-					request.setMethod(HttpMethod.PUT.name());
-					return request;
-				}))
+				.contentType(APPLICATION_JSON)
+				.content(request))
 			.andExpect(
 				result -> assertThat(result.getResolvedException()).isInstanceOf(IllegalArgumentException.class))
 			.andDo(document("duplicate-member",
@@ -166,66 +106,25 @@ public class MemberControllerTest {
 	@Test
 	@DisplayName("사용자는 자신의 프로필 닉네임만 변경할 수 있다.")
 	void updateMyProfileNickNameTest() throws Exception {
+
+		//given
+		String request = new ObjectMapper().writeValueAsString(new MemberRequest("updateNickName"));
+
 		//when then
-		mockMvc.perform(RestDocumentationRequestBuilders.multipart("/users/me")
+		mockMvc.perform(put("/users/me")
 				.header("Authorization", "Bearer " + accessJwt)
-				.content(MULTIPART_FORM_DATA_VALUE)
-				.param("nickName","updateNickName")
-				.with(request -> {
-					request.setMethod(HttpMethod.PUT.name());
-					return request;
-				}))
+				.contentType(APPLICATION_JSON)
+				.content(request))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.data.nickName", is("updateNickName")))
-			.andExpect(jsonPath("$.data.profileImgUrl", is("testImgUrl")))
 			.andDo(document("member-update-nickName",
 				getDocumentRequest(),
 				getDocumentResponse(),
 				requestHeaders(
 					headerWithName("Authorization").description("JWT Access 토큰")
 				),
-				queryParameters(
-					parameterWithName("nickName").description("수정할 닉네임")
-				),
-				responseFields(
-					fieldWithPath("code").type(STRING).description("결과 코드"),
-					fieldWithPath("message").type(STRING).description("결과 메시지"),
-					fieldWithPath("data.id").type(NUMBER).description("회원 아이디"),
-					fieldWithPath("data.email").type(STRING).description("회원 이메일"),
-					fieldWithPath("data.nickName").type(STRING).description("회원 닉네임"),
-					fieldWithPath("data.profileImgUrl").type(STRING).description("회원 프로필 사진 URL")
-				)
-			));
-	}
-	@Test
-	@DisplayName("사용자는 자신의 프로필 이미지만 변경할 수 있다.")
-	void updateMyProfileImageTest() throws Exception {
-		//given
-		String mockProfileImgUrl = "updateProfileImgUrl";
-		when(objectStorageService.profileImgSave(any())).thenReturn(mockProfileImgUrl);
-
-		MockMultipartFile mockFile = new MockMultipartFile("file", "test.jpg", "image/jpeg", new byte[0]);
-
-		//when then
-		mockMvc.perform(RestDocumentationRequestBuilders.multipart("/users/me")
-				.file(mockFile)
-				.header("Authorization", "Bearer " + accessJwt)
-				.content(MULTIPART_FORM_DATA_VALUE)
-				.with(request -> {
-					request.setMethod(HttpMethod.PUT.name());
-					return request;
-				}))
-			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.data.nickName", is("testNickName")))
-			.andExpect(jsonPath("$.data.profileImgUrl", is(mockProfileImgUrl)))
-			.andDo(document("member-update-Profile",
-				getDocumentRequest(),
-				getDocumentResponse(),
-				requestHeaders(
-					headerWithName("Authorization").description("JWT Access 토큰")
-				),
-				requestParts(
-					partWithName("file").description("업데이트할 파일")
+				requestFields(
+					fieldWithPath("nickName").description("수정할 닉네임")
 				),
 				responseFields(
 					fieldWithPath("code").type(STRING).description("결과 코드"),

--- a/src/test/java/com/clover/habbittracker/domain/member/dto/ProfileImgTest.java
+++ b/src/test/java/com/clover/habbittracker/domain/member/dto/ProfileImgTest.java
@@ -1,0 +1,21 @@
+package com.clover.habbittracker.domain.member.dto;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class ProfileImgTest {
+
+	@Test
+	@DisplayName("프로필 이미지를 랜덤으로 가져올 수 있다.")
+	void randomProfileImgTest() {
+		ProfileImg imgUrl = ProfileImg.getRandProfileImg();
+
+		assertTrue(
+			imgUrl == ProfileImg.HABITEE_DREAM ||
+			imgUrl == ProfileImg.HABITEE_HOPE ||
+			imgUrl == ProfileImg.HABITEE_LUCKY);
+	}
+
+}

--- a/src/test/java/com/clover/habbittracker/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/clover/habbittracker/domain/member/service/MemberServiceTest.java
@@ -50,39 +50,20 @@ public class MemberServiceTest {
 	}
 
 	@Test
-	@DisplayName("사용자에게 nickName,ProfileImgUrl을 요청받아, 사용자 프로필을 업데이트 할 수 있다.")
+	@DisplayName("사용자에게 nickName 요청받아, 사용자 프로필을 업데이트 할 수 있다.")
 	void successUpdateProfileTest() {
 
 		//given
-		MemberRequest memberRequest = MemberRequest.builder()
-			.nickName("updateNickName")
-			.profileImgUrl("updateImgUrl")
-			.build();
+		MemberRequest memberRequest = new MemberRequest("updateNickName");
 
 		//when
 		MemberResponse memberResponse = memberService.updateProfile(getId(), memberRequest);
 
 		//then
 		assertThat(memberResponse)
-			.hasFieldOrPropertyWithValue("nickName", memberRequest.getNickName())
-			.hasFieldOrPropertyWithValue("profileImgUrl", memberRequest.getProfileImgUrl());
+			.hasFieldOrPropertyWithValue("nickName", memberRequest.getNickName());
 	}
 
-	@Test
-	@DisplayName("사용자에게 nickName,ProfileImgUrl 하나만 요청 받아 사용자 프로필을 업데이트 할 수 있다.")
-	void optionUpdateProfileTest() {
-		//given
-		MemberRequest memberRequest = MemberRequest.builder().profileImgUrl("updateImgUrl2").build();
-
-		//when
-		MemberResponse memberResponse = memberService.updateProfile(1L, memberRequest);
-
-		//then
-		// 닉네임은 변경되고, 그 외의는 이전의 데이터와 같은지 비교
-		assertThat(memberResponse)
-			.hasFieldOrPropertyWithValue("profileImgUrl", memberRequest.getProfileImgUrl())
-			.hasFieldOrPropertyWithValue("nickName",getNickName());
-	}
 
 	@Test
 	@DisplayName("로그인을 할 경우 oauthId와 provider를 비교하여 사용자 정보가 없다면 자동으로 회원가입 한다.")


### PR DESCRIPTION
## 작업 사항
**_프로필 이미지 변경은 더 이상 사용자가 하는 것인 아닌 회원가입시 랜덤으로 배정하는 것으로 변경되었습니다.
따라서 프로필 이미지 업로드와 이미지 Url 업데이트 기능은 모두 제거하였습니다._**

---

[chore(dto) : 프로필 이미지 URL 제거](https://github.com/potenday-project/Habiters_BE/commit/535d4495734184e5fa61aec4bc0f6abb4ffaba46) 
- 프로필 이미지를 사용자가 수정 할 수 없으므로, MemberRequest 속성에서 제거 했습니다.
- 하나의 속성만을 갖고있기에, Builder 패턴을 사용하기보단 생성자를 사용하고자 빌더 어노테이션을 제거하였습니다.
 
[chore(service) : 프로필 이미지 랜덤 등록 추가](https://github.com/potenday-project/Habiters_BE/commit/6ecc2ae50b3e36bb0e86b2afffbe606d0b4d6bcd) 
- 회원 등록 시 프로필 이미지를 3개의 캐릭터중 랜덤으로 등록합니다.
- enum 클래스인 ProfileImg 에서 랜덤 이미지를 받아 URL 을 member 의 프로필 이미지 URL 으로 설정하도록 했습니다.
- 기존 회원 정보 update 메서드에서 ProfileImgUrl 부분은 제거 하였습니다.

[chore(controller) : 프로필 이미지 파일 업로드 기능 제거 및 프로필 이미지 수정기능 제거](https://github.com/potenday-project/Habiters_BE/commit/1be36ef0031c6f0a6ff9df942ecb2bd653c57eb4) 
- 프로필 수정은 더 이상 사용자가 하지않도록 변경하였습니다.
- 프로필 이미지는 회원 가입시 랜덤으로 배정되며, 해당 이미지는 사용자가 수정할 수 없도록 하고자 사용자에게 이미지 파일을 더 이상 받지 않습니다.
- 사진 업로드를 더 이상 하지 않기에, 네이버 클라우드의 스토리지 서버와의 의존성을 제거하였습니다.
 
[chore(oauth) : 소셜 프로필 이미지 제거](https://github.com/potenday-project/Habiters_BE/commit/cc7013a467bf06793ab97276741943567f36d246) 
- 직접 프로필 이미지를 배정하는 방식으로 사용함에 따라 소셜로그인 시 더 이상 프로필 이미지를 제공받지 않습니다.
- 따라서 ProfileImgUrl 은 삭제하였습니다.
 
[docs(ncp) : 스토리지 서버 미사용에 따른 주석문 추가](https://github.com/potenday-project/Habiters_BE/commit/7f3fdfaa003ef7e4af0a20bf991e0de1a2afefef) 
- 스토리지 서버를 더 이상 사용하지 않지만, 추후에 추가 될 가능성이 있어, 주석문으로 표기했습니다.
 
[feat(ProfileImg) : 자체 프로필 이미지 추가](https://github.com/potenday-project/Habiters_BE/commit/018638782069c7fa619b7290b17e7cb2355f7a00) 
- 자체적으로 사용하는 프로필 이미지를 추가하였습니다.
- 해당 프로필 이미지는 스토리지 서버에 올려뒀으며, URL 만 사용하고, 사용자가 직접 다운로드 프로필 이미지 업로드는 불가능합니다.
- 프로필 이미지를 스토리지 서버에 올린 후 사용하는 이유는 회원이 가입하였을 때 저장된 프로필 이미지는 계속 해서 사용해야 하므로 직접 파일을 저장 후 URL 만 주는 방식으로 추가하였습니다.
- 처음 회원 가입 시 프로필 사진을 선택하지 않고 랜덤으로 배정하는 방식이기에 랜덤으로 ProfileImg 를 리턴하는 static 함수를 추가하였습니다.
 
[feat(Test_ProfileImg) : 랜덤 프로필 이미지 배정 테스트](https://github.com/potenday-project/Habiters_BE/commit/c5a72d961ca1e2c5caf77e37142c073f17b0066c) 
- 랜덤으로 프로필을 정상적으로 가져오는지 확인하기 위한 테스트입니다.
- 랜덤으로 URL 을 계속 가져오는지 판별하고 싶었으나, 검증 과정 URL 두개를 비교하여 서로 다른지 검증하는 식으로 할 경우 랜덤으로 배정되기에 같은 이미지 URL 이 될 수 있습니다.
- 따라서 검증 부분은 정상적으로 ProfileImg 가 셋 중에 하나가 리턴 되는지 확인하는 방법을 검증하였습니다.
 
[chore(Test_Member) : MemberServiceTest 사용자 프로필 이미지 수정 테스트 제거](https://github.com/potenday-project/Habiters_BE/commit/4ad021bdf7e063c29a90f2473600b7079540f052) 
- 프로필 이미지를 수정하지 않으므로 기존 Profile 이미지를 수정하는 테스트를 전부 제거하였습니다.
- 또, MemberRequest 는 더 이상 빌더를 사용하지 않고, 생성자를 사용하므로 빌더를 사용한 코드도 수정하였습니다.
- 스토리지 서버로 프로필 업로드는 사용하지 않으므로, ObjectStorageService 는 제거하였습니다.