### PR TITLE
[#56] Feat :  유효성 검증 추가

### DIFF
--- a/src/main/java/com/clover/habbittracker/domain/diary/api/DiaryController.java
+++ b/src/main/java/com/clover/habbittracker/domain/diary/api/DiaryController.java
@@ -22,6 +22,7 @@ import com.clover.habbittracker.domain.diary.dto.DiaryResponse;
 import com.clover.habbittracker.domain.diary.service.DiaryService;
 import com.clover.habbittracker.global.dto.BaseResponse;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -32,7 +33,7 @@ public class DiaryController {
 	private final DiaryService diaryService;
 
 	@PostMapping
-	ResponseEntity<BaseResponse<Long>> createDiary(@AuthenticationPrincipal Long memberId, @RequestBody DiaryRequest request) {
+	ResponseEntity<BaseResponse<Long>> createDiary(@AuthenticationPrincipal Long memberId, @Valid @RequestBody DiaryRequest request) {
 		Long registerId = diaryService.register(memberId, request);
 		BaseResponse<Long> response = BaseResponse.of(registerId, DIARY_CREATE);
 		return ResponseEntity.status(HttpStatus.CREATED).body(response);
@@ -48,7 +49,7 @@ public class DiaryController {
 
 	@PutMapping("/{diaryId}")
 	ResponseEntity<BaseResponse<DiaryResponse>> updateDiary(@PathVariable Long diaryId,
-		@RequestBody DiaryRequest request) {
+		@Valid @RequestBody DiaryRequest request) {
 		DiaryResponse updateDiary = diaryService.updateDiary(diaryId, request);
 		BaseResponse<DiaryResponse> response = BaseResponse.of(updateDiary, DIARY_UPDATE);
 		return ResponseEntity.ok().body(response);

--- a/src/main/java/com/clover/habbittracker/domain/diary/dto/DiaryRequest.java
+++ b/src/main/java/com/clover/habbittracker/domain/diary/dto/DiaryRequest.java
@@ -1,22 +1,18 @@
 package com.clover.habbittracker.domain.diary.dto;
 
-import java.util.Optional;
-
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor
 @AllArgsConstructor
-
+@Getter
 public class DiaryRequest {
 
-	@Size(max = 200, message = "회고록은 200글자 이상 작성 할 수 없습니다.")
+	@Size(max = 200, message = "회고록은 200글자 이내로 작성해주세요.")
 	@NotNull(message = "회고록이 비어 있을 수 없습니다.")
 	private String content;
 
-	public String getContent() {
-		return Optional.ofNullable(content).orElseThrow(IllegalArgumentException::new);
-	}
 }

--- a/src/main/java/com/clover/habbittracker/domain/diary/dto/DiaryRequest.java
+++ b/src/main/java/com/clover/habbittracker/domain/diary/dto/DiaryRequest.java
@@ -2,13 +2,18 @@ package com.clover.habbittracker.domain.diary.dto;
 
 import java.util.Optional;
 
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor
 @AllArgsConstructor
+
 public class DiaryRequest {
 
+	@Size(max = 200, message = "회고록은 200글자 이상 작성 할 수 없습니다.")
+	@NotNull(message = "회고록이 비어 있을 수 없습니다.")
 	private String content;
 
 	public String getContent() {

--- a/src/main/java/com/clover/habbittracker/domain/habit/api/HabitController.java
+++ b/src/main/java/com/clover/habbittracker/domain/habit/api/HabitController.java
@@ -24,6 +24,7 @@ import com.clover.habbittracker.domain.habit.service.HabitService;
 import com.clover.habbittracker.domain.habitcheck.dto.HabitCheckRequest;
 import com.clover.habbittracker.global.dto.BaseResponse;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -45,7 +46,7 @@ public class HabitController {
 	@PostMapping
 	public ResponseEntity<BaseResponse<Long>> createHabit(
 			@AuthenticationPrincipal Long memberId,
-			@RequestBody HabitRequest request) {
+			@Valid @RequestBody HabitRequest request) {
 		Long registerId = habitService.register(memberId, request);
 		BaseResponse<Long> response = BaseResponse.of(registerId, HABIT_CREATE);
 		return ResponseEntity.status(HttpStatus.CREATED).body(response);
@@ -54,7 +55,7 @@ public class HabitController {
 	@PutMapping("{habitId}")
 	public ResponseEntity<BaseResponse<HabitResponse>> updateHabit(
 			@PathVariable Long habitId,
-			@RequestBody HabitRequest request) {
+			@Valid @RequestBody HabitRequest request) {
 		HabitResponse updateHabit = habitService.updateMyHabit(habitId, request);
 		BaseResponse<HabitResponse> response = BaseResponse.of(updateHabit, HABIT_UPDATE);
 		return ResponseEntity.ok().body(response);

--- a/src/main/java/com/clover/habbittracker/domain/habit/dto/HabitRequest.java
+++ b/src/main/java/com/clover/habbittracker/domain/habit/dto/HabitRequest.java
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class HabitRequest {
 
-	@Size(max = 10, message = "습관은 10글자 이상으로 작성해주세요.")
+	@Size(max = 10, message = "습관은 10글자 이내로 입력해주세요.")
 	@NotNull(message = "습관 내용이 비어 있을 수 없습니다.")
 	String content;
 }

--- a/src/main/java/com/clover/habbittracker/domain/habit/dto/HabitRequest.java
+++ b/src/main/java/com/clover/habbittracker/domain/habit/dto/HabitRequest.java
@@ -1,17 +1,17 @@
 package com.clover.habbittracker.domain.habit.dto;
 
-import java.util.Optional;
-
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Getter
 @AllArgsConstructor
 @NoArgsConstructor
 public class HabitRequest {
+
+	@Size(max = 10, message = "습관은 10글자 이상으로 작성해주세요.")
+	@NotNull(message = "습관 내용이 비어 있을 수 없습니다.")
 	String content;
-
-	public String getContent() {
-		return Optional.ofNullable(content).orElseThrow(IllegalArgumentException::new);
-	}
-
 }

--- a/src/main/java/com/clover/habbittracker/domain/member/api/MemberController.java
+++ b/src/main/java/com/clover/habbittracker/domain/member/api/MemberController.java
@@ -17,6 +17,7 @@ import com.clover.habbittracker.domain.member.dto.MemberResponse;
 import com.clover.habbittracker.domain.member.service.MemberService;
 import com.clover.habbittracker.global.dto.BaseResponse;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -35,7 +36,7 @@ public class MemberController {
 
 	@PutMapping("/me")
 	ResponseEntity<BaseResponse<MemberResponse>> updateMyProfile(@AuthenticationPrincipal Long memberId,
-		@RequestBody MemberRequest request) {
+		@Valid @RequestBody MemberRequest request) {
 		MemberResponse updateProfile = memberService.updateProfile(memberId, request);
 		BaseResponse<MemberResponse> response = BaseResponse.of(updateProfile, MEMBER_UPDATE);
 		return ResponseEntity.ok().body(response);

--- a/src/main/java/com/clover/habbittracker/domain/member/dto/MemberRequest.java
+++ b/src/main/java/com/clover/habbittracker/domain/member/dto/MemberRequest.java
@@ -1,5 +1,6 @@
 package com.clover.habbittracker.domain.member.dto;
 
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -8,5 +9,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class MemberRequest {
+	@Size(max = 12,message = "닉네임은 12자 이내로 입력해주세요.")
 	String nickName;
 }

--- a/src/main/java/com/clover/habbittracker/domain/member/entity/ProfileImg.java
+++ b/src/main/java/com/clover/habbittracker/domain/member/entity/ProfileImg.java
@@ -1,4 +1,4 @@
-package com.clover.habbittracker.domain.member.dto;
+package com.clover.habbittracker.domain.member.entity;
 
 import java.util.Random;
 

--- a/src/main/java/com/clover/habbittracker/domain/member/exception/MemberDuplicateNickName.java
+++ b/src/main/java/com/clover/habbittracker/domain/member/exception/MemberDuplicateNickName.java
@@ -1,0 +1,11 @@
+package com.clover.habbittracker.domain.member.exception;
+
+import com.clover.habbittracker.global.exception.BaseException;
+import com.clover.habbittracker.global.exception.ErrorType;
+
+public class MemberDuplicateNickName extends BaseException {
+
+	public MemberDuplicateNickName(String nickName) {
+		super(nickName, ErrorType.MEMBER_DUPLICATE_NICKNAME);
+	}
+}

--- a/src/main/java/com/clover/habbittracker/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/clover/habbittracker/domain/member/service/MemberServiceImpl.java
@@ -7,8 +7,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.clover.habbittracker.domain.member.dto.MemberRequest;
 import com.clover.habbittracker.domain.member.dto.MemberResponse;
-import com.clover.habbittracker.domain.member.dto.ProfileImg;
+import com.clover.habbittracker.domain.member.entity.ProfileImg;
 import com.clover.habbittracker.domain.member.entity.Member;
+import com.clover.habbittracker.domain.member.exception.MemberDuplicateNickName;
 import com.clover.habbittracker.domain.member.exception.MemberNotFoundException;
 import com.clover.habbittracker.domain.member.repository.MemberRepository;
 import com.clover.habbittracker.global.security.oauth.dto.SocialUser;
@@ -66,7 +67,7 @@ public class MemberServiceImpl implements MemberService {
 			Optional.ofNullable(request.getNickName()).ifPresent(member::setNickName);
 			return member;
 		} else {
-			throw new IllegalArgumentException();
+			throw new MemberDuplicateNickName(byNickName.get().getNickName());
 		}
 	}
 }

--- a/src/main/java/com/clover/habbittracker/global/dto/ErrorResponse.java
+++ b/src/main/java/com/clover/habbittracker/global/dto/ErrorResponse.java
@@ -1,5 +1,9 @@
 package com.clover.habbittracker.global.dto;
 
+import java.util.Objects;
+
+import org.springframework.validation.BindingResult;
+
 import com.clover.habbittracker.global.exception.ErrorType;
 
 import lombok.Builder;
@@ -15,6 +19,13 @@ public class ErrorResponse {
 		return ErrorResponse.builder()
 			.errorName(errorType.name())
 			.msg(errorType.getErrorMsg())
+			.build();
+	}
+
+	public static ErrorResponse from(BindingResult bindingResult) {
+		return ErrorResponse.builder()
+			.errorName(Objects.requireNonNull(bindingResult.getFieldError()).getObjectName().toUpperCase())
+			.msg(bindingResult.getFieldError().getDefaultMessage())
 			.build();
 	}
 

--- a/src/main/java/com/clover/habbittracker/global/exception/ErrorType.java
+++ b/src/main/java/com/clover/habbittracker/global/exception/ErrorType.java
@@ -14,6 +14,7 @@ public enum ErrorType {
 	EXPIRED_JWT(HttpStatus.BAD_REQUEST,"유효시간이 만료된 토큰입니다."),
 
 	MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "회원 정보가 존재하지 않습니다."),
+	MEMBER_DUPLICATE_NICKNAME(HttpStatus.CONFLICT, "중복된 닉네임 입니다."),
 
 	HABIT_NOT_FOUND(HttpStatus.NOT_FOUND, "습관 정보가 존재하지 않습니다."),
 	HABIT_CHECK_DUPLICATE(HttpStatus.CONFLICT, "중복 체크는 불가능합니다."),

--- a/src/main/java/com/clover/habbittracker/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/clover/habbittracker/global/exception/GlobalExceptionHandler.java
@@ -3,6 +3,8 @@ package com.clover.habbittracker.global.exception;
 import static com.clover.habbittracker.global.util.MyLogger.*;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -32,5 +34,12 @@ public class GlobalExceptionHandler {
 		ErrorType errorType = ErrorType.INVALID_ARGUMENTS;
 		commonExceptionWarnLogging(request, e, errorType);
 		return new ResponseEntity<>(ErrorResponse.from(errorType), errorType.getStatus());
+	}
+	@ExceptionHandler(MethodArgumentNotValidException.class)
+	public ResponseEntity<ErrorResponse> validationException(HttpServletRequest request, MethodArgumentNotValidException e) {
+		ErrorType errorType = ErrorType.INVALID_ARGUMENTS;
+		BindingResult bindingResult = e.getBindingResult();
+		commonExceptionWarnLogging(request, e, errorType);
+		return new ResponseEntity<>(ErrorResponse.from(bindingResult), errorType.getStatus());
 	}
 }

--- a/src/main/java/com/clover/habbittracker/global/util/DateUtil.java
+++ b/src/main/java/com/clover/habbittracker/global/util/DateUtil.java
@@ -2,7 +2,6 @@ package com.clover.habbittracker.global.util;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.Year;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -22,9 +21,10 @@ public class DateUtil {
 	}
 
 	public static LocalDate getLocalDate(String date) {
-
-		String formattedDate = Year.now().getValue() + "-" + date;
-		return LocalDate.parse(formattedDate);
+		String[] parts = date.split("-");
+		int month = Integer.parseInt(parts[0]);
+		int day = Integer.parseInt(parts[1]);
+		return LocalDate.of(LocalDate.now().getYear(), month, day);
 	}
 
 }

--- a/src/test/java/com/clover/habbittracker/domain/diary/api/DiaryControllerTest.java
+++ b/src/test/java/com/clover/habbittracker/domain/diary/api/DiaryControllerTest.java
@@ -160,7 +160,10 @@ public class DiaryControllerTest {
 	@Test
 	@DisplayName("사용자는 회고록을 월 별로 조회 할 수 있다.")
 	void getAMonthlyMyDiaryListTest() throws Exception {
-		String date = "2023-05";
+		//given
+		LocalDateTime now = LocalDateTime.now();
+		String date = now.getYear() + "-0" + now.getMonthValue();
+
 		//when then
 		mockMvc.perform(
 				get("/diaries")

--- a/src/test/java/com/clover/habbittracker/domain/diary/dto/DiaryRequestTest.java
+++ b/src/test/java/com/clover/habbittracker/domain/diary/dto/DiaryRequestTest.java
@@ -1,0 +1,55 @@
+package com.clover.habbittracker.domain.diary.dto;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+
+public class DiaryRequestTest {
+	private static Validator validator;
+
+	@BeforeAll
+	public static void setup() {
+		ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+		validator = factory.getValidator();
+	}
+
+	@Test
+	@DisplayName("회고록 내용이 없을 경우 validation 에러가 발생하며, 에러 메세지를 출력한다.")
+	public void diaryValueNullTest() {
+		//given
+		DiaryRequest request = new DiaryRequest();
+
+		//when
+		Set<ConstraintViolation<DiaryRequest>> violations = validator.validate(request);
+		ConstraintViolation<DiaryRequest> violation = violations.iterator().next();
+
+		//then
+		assertThat(violation).isNotNull();
+		assertThat(violation.getMessage()).isEqualTo("회고록이 비어 있을 수 없습니다.");
+	}
+
+	@Test
+	@DisplayName("회고록 내용이 200자 이상이면 validation 에러가 발생하며, 에러 메세지를 출력한다.")
+	void diaryMaxSizeTest() {
+		//given
+		DiaryRequest request = new DiaryRequest("a".repeat(201));
+
+		//when
+		Set<ConstraintViolation<DiaryRequest>> violations = validator.validate(request);
+		ConstraintViolation<DiaryRequest> violation = violations.iterator().next();
+
+		//then
+		assertThat(violation).isNotNull();
+		assertThat(violation.getMessage()).isEqualTo("회고록은 200글자 이내로 작성해주세요.");
+
+	}
+}

--- a/src/test/java/com/clover/habbittracker/domain/diary/service/DiaryServiceTest.java
+++ b/src/test/java/com/clover/habbittracker/domain/diary/service/DiaryServiceTest.java
@@ -114,17 +114,6 @@ public class DiaryServiceTest {
 	}
 
 	@Test
-	@DisplayName("회고 내용이 없다면 등록 시 예외가 터진다.")
-	void failedRegisterDiaryTest() {
-		//given
-		Long testMemberId = testMember.getId();
-		DiaryRequest diaryRequest = new DiaryRequest(null);
-
-		//when then
-		assertThrows(IllegalArgumentException.class, () -> diaryService.register(testMemberId, diaryRequest));
-	}
-
-	@Test
 	@DisplayName("잘못된 회고록 ID, 사용자 ID 를 요청하면 예외가 터진다.")
 	void wrongHabitIdTest() {
 		//given

--- a/src/test/java/com/clover/habbittracker/domain/habit/api/HabitControllerTest.java
+++ b/src/test/java/com/clover/habbittracker/domain/habit/api/HabitControllerTest.java
@@ -13,6 +13,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -258,10 +259,13 @@ public class HabitControllerTest {
 		//given
 		HabitCheck testHabitCheck = HabitCheck.builder().habit(testHabit).checked(true).build();
 		habitCheckRepository.save(testHabitCheck);
+		LocalDateTime now = LocalDateTime.now();
+		String date = now.getYear() + "-0" + now.getMonthValue();
 
+		//when then
 		mockMvc.perform(
 				get("/habits")
-					.header("Authorization", "Bearer " + accessJwt).param("date","2023-05"))
+					.header("Authorization", "Bearer " + accessJwt).param("date",date))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.data.[0].id").exists())
 			.andExpect(jsonPath("$.data.[0].content").exists())
@@ -363,7 +367,7 @@ public class HabitControllerTest {
 	void habitCheckTestWithExpiredDate() throws Exception {
 		//given
 		LocalDate yesterday = LocalDate.now().minusDays(1);
-		String past = "0" + yesterday.getMonthValue() + "-" + yesterday.getDayOfMonth();
+		String past = yesterday.getMonthValue() + "-" + yesterday.getDayOfMonth();
 		String request = mapper.writeValueAsString(new HabitCheckRequest(past));
 
 		//when then

--- a/src/test/java/com/clover/habbittracker/domain/habit/dto/HabitRequestTest.java
+++ b/src/test/java/com/clover/habbittracker/domain/habit/dto/HabitRequestTest.java
@@ -1,0 +1,42 @@
+package com.clover.habbittracker.domain.habit.dto;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.clover.habbittracker.domain.member.dto.MemberRequest;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+
+public class HabitRequestTest {
+	private static Validator validator;
+
+	@BeforeAll
+	public static void setup() {
+		ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+		validator = factory.getValidator();
+	}
+
+	@Test
+	@DisplayName("닉네임이 12자 이상이면 validation 에러가 발생하며, 에러 메세지를 출력한다.")
+	void nickNameMaxSizeTest() {
+		//given
+		MemberRequest request = new MemberRequest("a".repeat(13));
+
+		//when
+		Set<ConstraintViolation<MemberRequest>> violations = validator.validate(request);
+		ConstraintViolation<MemberRequest> violation = violations.iterator().next();
+
+		//then
+		assertThat(violation).isNotNull();
+		assertThat(violation.getMessage()).isEqualTo("닉네임은 12자 이내로 입력해주세요.");
+
+	}
+}

--- a/src/test/java/com/clover/habbittracker/domain/habit/service/HabitServiceTest.java
+++ b/src/test/java/com/clover/habbittracker/domain/habit/service/HabitServiceTest.java
@@ -69,15 +69,13 @@ public class HabitServiceTest {
 	}
 
 	@Test
-	@DisplayName("올바르지 않은 사용자 ID 또는 습관 내용이 없다면 등록 시 예외가 터진다.")
+	@DisplayName("올바르지 않은 사용자 ID 로 습관 등록 요청 시 예외가 발생한다.")
 	void failedRegisterHabitTest() {
 		//given
-		Long testMemberId = testMember.getId();
 		Long wrongMemberId = 0L;
 		HabitRequest habitRequest = new HabitRequest(null);
 
 		//when then
-		assertThrows(IllegalArgumentException.class, () -> habitService.register(testMemberId, habitRequest));
 		assertThrows(MemberNotFoundException.class, () -> habitService.register(wrongMemberId, habitRequest));
 	}
 

--- a/src/test/java/com/clover/habbittracker/domain/member/api/MemberControllerTest.java
+++ b/src/test/java/com/clover/habbittracker/domain/member/api/MemberControllerTest.java
@@ -115,7 +115,7 @@ public class MemberControllerTest {
 				.contentType(APPLICATION_JSON)
 				.content(request))
 			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.data.nickName", is("updateNickName")))
+			.andExpect(jsonPath("$.data.nickName", is("updateNick")))
 			.andDo(document("member-update-nickName",
 				getDocumentRequest(),
 				getDocumentResponse(),

--- a/src/test/java/com/clover/habbittracker/domain/member/api/MemberControllerTest.java
+++ b/src/test/java/com/clover/habbittracker/domain/member/api/MemberControllerTest.java
@@ -25,6 +25,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.clover.habbittracker.domain.member.dto.MemberRequest;
 import com.clover.habbittracker.domain.member.entity.Member;
+import com.clover.habbittracker.domain.member.exception.MemberDuplicateNickName;
 import com.clover.habbittracker.domain.member.repository.MemberRepository;
 import com.clover.habbittracker.global.security.jwt.JwtProvider;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -84,14 +85,13 @@ public class MemberControllerTest {
 	void updateNickNameDuplicateTest() throws Exception {
 		//given
 		String request = new ObjectMapper().writeValueAsString(new MemberRequest("testNickName"));
-
 		//when then
 		mockMvc.perform(put("/users/me")
 				.header("Authorization", "Bearer " + accessJwt)
 				.contentType(APPLICATION_JSON)
 				.content(request))
 			.andExpect(
-				result -> assertThat(result.getResolvedException()).isInstanceOf(IllegalArgumentException.class))
+				result -> assertThat(result.getResolvedException()).isInstanceOf(MemberDuplicateNickName.class))
 			.andDo(document("duplicate-member",
 				getDocumentRequest(),
 				getDocumentResponse(),

--- a/src/test/java/com/clover/habbittracker/domain/member/api/MemberControllerTest.java
+++ b/src/test/java/com/clover/habbittracker/domain/member/api/MemberControllerTest.java
@@ -107,7 +107,7 @@ public class MemberControllerTest {
 	@DisplayName("사용자는 자신의 프로필 닉네임만 변경할 수 있다.")
 	void updateMyProfileNickNameTest() throws Exception {
 		//given
-		String request = new ObjectMapper().writeValueAsString(new MemberRequest("updateNickName"));
+		String request = new ObjectMapper().writeValueAsString(new MemberRequest("updateNick"));
 
 		//when then
 		mockMvc.perform(put("/users/me")

--- a/src/test/java/com/clover/habbittracker/domain/member/dto/MemberRequestTest.java
+++ b/src/test/java/com/clover/habbittracker/domain/member/dto/MemberRequestTest.java
@@ -1,0 +1,57 @@
+package com.clover.habbittracker.domain.member.dto;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.clover.habbittracker.domain.habit.dto.HabitRequest;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+
+public class MemberRequestTest {
+	private static Validator validator;
+
+	@BeforeAll
+	public static void setup() {
+		ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+		validator = factory.getValidator();
+	}
+
+	@Test
+	@DisplayName("습관 내용이 없을 경우 validation 에러가 발생하며, 에러 메세지를 출력한다.")
+	public void diaryValueNullTest() {
+		//given
+		HabitRequest request = new HabitRequest();
+
+		//when
+		Set<ConstraintViolation<HabitRequest>> violations = validator.validate(request);
+		ConstraintViolation<HabitRequest> violation = violations.iterator().next();
+
+		//then
+		assertThat(violation).isNotNull();
+		assertThat(violation.getMessage()).isEqualTo("습관 내용이 비어 있을 수 없습니다.");
+	}
+
+	@Test
+	@DisplayName("습관 내용이 10자 이상이면 validation 에러가 발생하며, 에러 메세지를 출력한다.")
+	void diaryMaxSizeTest() {
+		//given
+		HabitRequest request = new HabitRequest("a".repeat(11));
+
+		//when
+		Set<ConstraintViolation<HabitRequest>> violations = validator.validate(request);
+		ConstraintViolation<HabitRequest> violation = violations.iterator().next();
+
+		//then
+		assertThat(violation).isNotNull();
+		assertThat(violation.getMessage()).isEqualTo("습관은 10글자 이내로 입력해주세요.");
+
+	}
+}

--- a/src/test/java/com/clover/habbittracker/domain/member/dto/ProfileImgTest.java
+++ b/src/test/java/com/clover/habbittracker/domain/member/dto/ProfileImgTest.java
@@ -5,6 +5,8 @@ import static org.junit.jupiter.api.Assertions.*;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import com.clover.habbittracker.domain.member.entity.ProfileImg;
+
 public class ProfileImgTest {
 
 	@Test

--- a/src/test/java/com/clover/habbittracker/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/clover/habbittracker/domain/member/service/MemberServiceTest.java
@@ -12,6 +12,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 
 import com.clover.habbittracker.domain.member.dto.MemberRequest;
 import com.clover.habbittracker.domain.member.dto.MemberResponse;
+import com.clover.habbittracker.domain.member.exception.MemberDuplicateNickName;
 import com.clover.habbittracker.domain.member.exception.MemberNotFoundException;
 import com.clover.habbittracker.domain.member.repository.MemberRepository;
 import com.clover.habbittracker.global.security.oauth.dto.GoogleUser;
@@ -62,6 +63,18 @@ public class MemberServiceTest {
 		//then
 		assertThat(memberResponse)
 			.hasFieldOrPropertyWithValue("nickName", memberRequest.getNickName());
+	}
+	@Test
+	@DisplayName("중복된 닉네임은 사용 할 수 없습니다.")
+	void failedUpdateProfileTest() {
+
+		//given
+		MemberRequest memberRequest = new MemberRequest("testNickName");
+
+		//when then
+		assertThrows(MemberDuplicateNickName.class, () -> {
+			memberService.updateProfile(getId(), memberRequest);
+		});
 	}
 
 


### PR DESCRIPTION
## 작업 사항 [#56] 

**_습관, 회고록, 닉네임 을 등록,수정 할 경우 유효성 검증 과정을 추가하였습니다. JavaBean Validation 라이브러리를 사용하여 유효성을 검증하도록 하였습니다. 커밋 내용이 많아서.. 커밋 메세지에 상세하게 작성해뒀습니다_**

[chore(dto) : ProfileImg 클래스 패키지 이동](https://github.com/potenday-project/Habiters_BE/commit/f7920048c8e4c6b22bb30924b4977c4a11ea9a6d) 

 
[chore(dto) : ProfileImg 클래스 패키지 이동](https://github.com/potenday-project/Habiters_BE/commit/bc13ae581ee9b420c4fdb23f984cf474632bf969) 

 
[feat(Service) : 닉네임 중복 예외 클래스 추가](https://github.com/potenday-project/Habiters_BE/commit/a84f30845d816a7db21628f672f4eec8be8700ae) 

 
[feat(Test_Service) : 닉네임 중복 예외 테스트 추가](https://github.com/potenday-project/Habiters_BE/commit/7e13c77daf100eddd6507381389cb772a039ded7) 


[chore(Test_Controller) : MemberControllerTest 닉네임 중복 검증 수정](https://github.com/potenday-project/Habiters_BE/commit/c0c290a508ad87c96ed4bc24b3aad4d285d8fd9f) 

 
[feat(Exception) : 중복 닉네임 예외 클래스 추가](https://github.com/potenday-project/Habiters_BE/commit/154bf9b83ac20711d09a9de4ff556c1db5b3b7b5) 

 
[chore(Exception) : ErrorType 중복 닉네임 추가](https://github.com/potenday-project/Habiters_BE/commit/b8d6d3decc540d5b517c5eefefcbefe0627c5aa8) 

 
[feat(dto) : 유효성 검증 추가](https://github.com/potenday-project/Habiters_BE/commit/ba5e6e5774648aab71da25325e72a61461f3357e) 
 
[feat(Exception) : ErrorResponse from 팩토리 메서드 오버로딩](https://github.com/potenday-project/Habiters_BE/commit/5504d01d59c3ede10081ebdf809aeb5e13046e8c) 
 

[fix(Test_Habit) : HabitControllerTest 월별 조회 수정](https://github.com/potenday-project/Habiters_BE/commit/8a393800ef6dea20a19460204233dc8b1512f683) 
 
[chore(dto) : DiaryRequest 오타 및 getter 수정](https://github.com/potenday-project/Habiters_BE/commit/72c902af1c5b80efc630ec20650db2c487b49bf7) 

 
[chore(dto) : HabitRequest 오타 수정](https://github.com/potenday-project/Habiters_BE/commit/3cd5be9815ae691c89f492221b8138c2d0a52299) 

 
[feat(dto) : MemberRequest 유효성 검증 추가](https://github.com/potenday-project/Habiters_BE/commit/95f08203fda6b38ede98e6901f816396402fc8d8) 

 
[chore(Test_Habit) : HabitServiceTest 등록 예외 검증 테스트 수정](https://github.com/potenday-project/Habiters_BE/commit/d8bfc3695b2a7fa1bffb04fe5361373c4eff6845) 

 
[chore(Test_Diary) : DiaryServiceTest 등록 예외 검증 테스트 수정](https://github.com/potenday-project/Habiters_BE/commit/a6acb9bc62ad3edcdccc6ab1c222044b4dd68377) 

 
[feat(Test_dto) : Request Validation 테스트 코드 추가](https://github.com/potenday-project/Habiters_BE/commit/fa1f2f7ce93becfa08dd1bed6fbfb6644b00ca63) 

 

[feat(Controller) : Controller Validation 검증 추가](https://github.com/potenday-project/Habiters_BE/commit/65ca09eca985893cab9eb49c85954308e681dbea) 

 
[feat(Exception) : ExceptionHandler 예외 추가](https://github.com/potenday-project/Habiters_BE/commit/f0664720af253e9e2b6ff9efb44d010fe2e45241) 

---

## 작업 사항 [#58]
### getLocalDate 함수를 사용하는 테스트 코드가 전부 실패하는 상황으로 유효성 검증 작업과 같이 진행하게 되었습니다...

**_DataUtil 내에 getLocalDate 를 호출 할 경우 date 형식으로 반드시 MM-dd 형식으로 받아와야지만 처리가 가능하다는 문제점이 있었습니다.
기존 테스트 코드에서도 해당 문제가 발생 하였지만, 크게 개의치 않게 생각하여 직접 숫자를 붙여주는 방식으로 테스트를 진행하였습니다.
하지만 int 형태로 월일을 받기때문에 직접 0을 붙여서 데이터를 처리하는 방법은 매우 비효율적이고 잘못된 방법이라고 생각하여 date 는 반드시 "-" 로 월 일 을 구분하여 받고 int 로 LocalDate 를 만드는 방식으로 수정하였습니다._**

[fix(Util) : DateUtil 메서드 수정](https://github.com/potenday-project/Habiters_BE/commit/d3843144aaf1ad68a57f4cc54ac796e4201ba0e6)

[fix(Test_Diary) : DiaryControllerTest 월별 조회 수정](https://github.com/potenday-project/Habiters_BE/commit/18f44d90b6324632a4760075fd59febe8c059240)

[fix(Test_Habit) : HabitControllerTest 월별 조회 수정](https://github.com/potenday-project/Habiters_BE/commit/8a393800ef6dea20a19460204233dc8b1512f683)