### PR TITLE
[#60] Fix : 회원 프로필 사진 및 소셜 닉네임 검증 추가

### DIFF
--- a/src/main/java/com/clover/habbittracker/domain/member/entity/ProfileImg.java
+++ b/src/main/java/com/clover/habbittracker/domain/member/entity/ProfileImg.java
@@ -7,9 +7,9 @@ import lombok.Getter;
 @Getter
 public enum ProfileImg {
 
-	HABITEE_LUCKY("https://kr.object.ncloudstorage.com/user-profile-image/Habitee_Lucky.png"),
-	HABITEE_HOPE("https://kr.object.ncloudstorage.com/user-profile-image/Habitee_Hope.png"),
-	HABITEE_DREAM("https://kr.object.ncloudstorage.com/user-profile-image/Habitee_Dream.png");
+	HABITEE_LUCKY("https://kr.object.ncloudstorage.com/user-profile-image/Habitee_Lucky.svg"),
+	HABITEE_HOPE("https://kr.object.ncloudstorage.com/user-profile-image/Habitee_Hope.svg"),
+	HABITEE_DREAM("https://kr.object.ncloudstorage.com/user-profile-image/Habitee_Dream.svg");
 
 	private final String imgUrl;
 

--- a/src/main/java/com/clover/habbittracker/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/clover/habbittracker/domain/member/service/MemberServiceImpl.java
@@ -7,8 +7,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.clover.habbittracker.domain.member.dto.MemberRequest;
 import com.clover.habbittracker.domain.member.dto.MemberResponse;
-import com.clover.habbittracker.domain.member.entity.ProfileImg;
 import com.clover.habbittracker.domain.member.entity.Member;
+import com.clover.habbittracker.domain.member.entity.ProfileImg;
 import com.clover.habbittracker.domain.member.exception.MemberDuplicateNickName;
 import com.clover.habbittracker.domain.member.exception.MemberNotFoundException;
 import com.clover.habbittracker.domain.member.repository.MemberRepository;
@@ -55,7 +55,7 @@ public class MemberServiceImpl implements MemberService {
 			Member.builder()
 				.email(socialUser.getEmail())
 				.oauthId(socialUser.getOauthId())
-				.nickName("해빗터_" + socialUser.getNickName())
+				.nickName("해비터_" + socialUser.getNickName())
 				.provider(socialUser.getProvider())
 				.profileImgUrl(ProfileImg.getRandProfileImg().getImgUrl())
 				.build());

--- a/src/main/java/com/clover/habbittracker/global/security/oauth/dto/GoogleUser.java
+++ b/src/main/java/com/clover/habbittracker/global/security/oauth/dto/GoogleUser.java
@@ -20,7 +20,7 @@ public class GoogleUser implements SocialUser{
 
 	@Override
 	public String getNickName() {
-		return this.nickName;
+		return trimNickName(nickName);
 	}
 
 	@Override

--- a/src/main/java/com/clover/habbittracker/global/security/oauth/dto/KakaoUser.java
+++ b/src/main/java/com/clover/habbittracker/global/security/oauth/dto/KakaoUser.java
@@ -20,7 +20,7 @@ public class KakaoUser implements SocialUser{
 
 	@Override
 	public String getNickName() {
-		return this.nickName;
+		return trimNickName(nickName);
 	}
 
 	@Override

--- a/src/main/java/com/clover/habbittracker/global/security/oauth/dto/NaverUser.java
+++ b/src/main/java/com/clover/habbittracker/global/security/oauth/dto/NaverUser.java
@@ -20,7 +20,7 @@ public class NaverUser implements SocialUser {
 
 	@Override
 	public String getNickName() {
-		return this.nickName;
+		return trimNickName(nickName);
 	}
 
 	@Override

--- a/src/main/java/com/clover/habbittracker/global/security/oauth/dto/SocialUser.java
+++ b/src/main/java/com/clover/habbittracker/global/security/oauth/dto/SocialUser.java
@@ -13,6 +13,10 @@ public interface SocialUser {
 
 	default String trimNickName(String nickName) {
 
+		if(nickName == null) {
+			return null;
+		}
+
 		if(nickName.length() > 8){
 			nickName = nickName.replace(" ","").substring(0, 8);
 		}

--- a/src/main/java/com/clover/habbittracker/global/security/oauth/dto/SocialUser.java
+++ b/src/main/java/com/clover/habbittracker/global/security/oauth/dto/SocialUser.java
@@ -10,6 +10,12 @@ public interface SocialUser {
 	String getProvider();
 
 	String getOauthId();
-	//
-	// String getProfileImgUrl();
+
+	default String trimNickName(String nickName) {
+
+		if(nickName.length() > 8){
+			nickName = nickName.replace(" ","").substring(0, 8);
+		}
+		return nickName;
+	}
 }

--- a/src/test/java/com/clover/habbittracker/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/clover/habbittracker/domain/member/service/MemberServiceTest.java
@@ -98,5 +98,21 @@ public class MemberServiceTest {
 		assertThat(savedUserId).isEqualTo(getId());
 	}
 
+	@Test
+	@DisplayName("회원 가입을 할 경우 닉네임이 8자 이상이라면, \"해비터_\"를 공백을 제외한 8자까지 닉네임을 사용한다")
+	void memberRegisterTrimNickNameTest() {
+		//given
+		SocialUser newUser = GoogleUser.builder()
+			.oauthId("GoogleOauthId")
+			.provider("google")
+			.nickName("test Nick Name")
+			.build();
+		Long newMemberID = memberService.join(newUser);
+		//when
+		MemberResponse profile = memberService.getProfile(newMemberID);
+		//then
+		assertThat(profile.getNickName().substring(4)).isEqualTo(newUser.getNickName().replace(" ","").substring(0,8));
+
+	}
 
 }

--- a/src/test/java/com/clover/habbittracker/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/clover/habbittracker/domain/member/service/MemberServiceTest.java
@@ -85,10 +85,12 @@ public class MemberServiceTest {
 		SocialUser newUser = GoogleUser.builder()
 			.oauthId("GoogleOauthId")
 			.provider("google")
+			.nickName(getNickName())
 			.build();
 		SocialUser savedUser = GoogleUser.builder()
 			.oauthId("testOauthId")
 			.provider("testProvider")
+			.nickName(getNickName())
 			.build();
 		//when
 		Long newMemberID = memberService.join(newUser);


### PR DESCRIPTION
## 작업 사항 [#60]
Q/A 에서 나온 소셜 회원 가입 시 소셜 닉네임이 포함 12자가 넘어가는 경우가 있습니다. 따라서 소셜 닉네임을 받아 올 경우 닉네임을 "해비터"를 제외하고 8자까지만 사용하도록 문자열을 잘라서 가져오도록 하였습니다.
또, 프로필 이미지를 png 파일에서 svg 로 변경됨에 따라 ProfileImg 의 url 을 .svg 로 변경하였습니다.
"해빗터"를 사용하지 않고, "해비터" 를 기본 닉네임으로 설정하도록 변경하였습니다

---

[chore(Service) : MemberServiceImpl 회원가입 수정](https://github.com/potenday-project/Habiters_BE/commit/83aa3e42a774b9c323877cf1ad5cdfbf0e57d4c0) 
- 회원 가입 시 기존 "해빗터" -> "해비터" 로 변경하였습니다.
 
[chore(Dto) : ProfileImg 파일 url 변경](https://github.com/potenday-project/Habiters_BE/commit/e4c7f3b8caddcbe8b50111e930f6661901adee4c) 
- png 파일에서 svg 파일로 수정됨에 따라 url 을 수정하였습니다.
 
[chore(oauth) : Google,Naver,Kakao getNickName 수정](https://github.com/potenday-project/Habiters_BE/commit/f165790fe6e478ff5abe87dfd18551de82dbf6b1) 
- getNickName 메서드에 SocialUser 에서 직접 구현한 trimNickName 을 사용하여 글자수를 잘라서 가져오도록 하였습니다.
 


[feat(oauth) : SocialUser 닉네임 글자수 제한 추가](https://github.com/potenday-project/Habiters_BE/commit/e5831131a2f67e8e615353ce319e78f1ed303914) / [trimNicName Null 처리](https://github.com/potenday-project/Habiters_BE/commit/ca14d841079312ce29f00cf8b4d0116fbfa537da) 
- nickName 이 null 일 경우 null 로 반환 하도록 하였습니다.
- 소셜 회원 가입 시 기존은 닉네임의 글자수를 따로 제한하지 않았습니다.
- 하지만 닉네임 최대 글자수 제한이 생김에 따라 소셜 닉네임이 "해비터_" 포함 12자 이상이 되어 유효성을 추가하여도 의미가 퇴색되었습니다.
- 따라서 소셜 닉네임이 "해비터_" 제외 8글자가 넘어간다면 안되기에 소셜 닉네임이 8글자가 넘어간다면 8글자 까지만 가져오는 메서드를 추가하였습니다.
- 메서드는 매개변수로 받는 닉네임을 자르고 반환하기에 메서드 명에 trim 을 사용하였습니다.
- default 를 활용하여 해당 SocialUser 를 구현하는 객체들이 사용 할 수 있게 하였습니다.


[chore(Test_Member) : MemberServiceTest 소셜 닉네임 제한 테스트 추가](https://github.com/potenday-project/Habiters_BE/commit/32c5a2f0a4fdf84955e0101b8a1b4fc2f5168416) / [회원가입 테스트 수정](https://github.com/potenday-project/Habiters_BE/commit/5b4d7be6526563836049f721857f3247c94c194d) 
- 소셜 회원 객체 생성 시 NickName 을 추가하였습니다.
- 회원 가입을 진행 후 조회 했을 경우 소셜 닉네임이 정상적으로 8글자만 출력 되는지 확인 하는 테스트입니다.
- "해비터_" 는 제외하고, 소셜 닉네임의 글자수만 검증하므로, 조회해서 가져온 profile 에서 "해비터_" 는 제외 한 후 검증하도록 하였습니다.
