### PR TITLE
[#56]Fix : 회고록 반환 데이터 추가

### DIFF
--- a/src/main/java/com/clover/habbittracker/domain/diary/dto/DiaryResponse.java
+++ b/src/main/java/com/clover/habbittracker/domain/diary/dto/DiaryResponse.java
@@ -13,12 +13,14 @@ public class DiaryResponse {
 	private Long id;
 	private String content;
 	private LocalDateTime createDate;
+	private LocalDateTime endUpdateDate;
 
 	public static DiaryResponse from(Diary diary) {
 		return DiaryResponse.builder()
 			.id(diary.getId())
 			.content(diary.getContent())
-			.createDate(diary.getUpdatedAt())
+			.createDate(diary.getCreatedAt())
+			.endUpdateDate(diary.getEndUpdateDate())
 			.build();
 	}
 

--- a/src/test/java/com/clover/habbittracker/domain/diary/api/DiaryControllerTest.java
+++ b/src/test/java/com/clover/habbittracker/domain/diary/api/DiaryControllerTest.java
@@ -130,7 +130,8 @@ public class DiaryControllerTest {
 					fieldWithPath("message").type(STRING).description("결과 메시지"),
 					fieldWithPath("data.id").type(NUMBER).description("회고록 아이디"),
 					fieldWithPath("data.content").type(STRING).description("회고록 내용"),
-					fieldWithPath("data.createDate").type(STRING).description("회고록 등록 날짜")
+					fieldWithPath("data.createDate").type(STRING).description("회고록 등록 날짜"),
+					fieldWithPath("data.endUpdateDate").type(STRING).description("회고 수정 마감 날짜")
 				)));
 	}
 
@@ -153,7 +154,8 @@ public class DiaryControllerTest {
 					fieldWithPath("message").type(STRING).description("결과 메시지"),
 					fieldWithPath("data[].id").type(NUMBER).description("회고록 아이디"),
 					fieldWithPath("data[].content").type(STRING).description("회고록 내용"),
-					fieldWithPath("data[].createDate").type(STRING).description("회고 등록 날짜")
+					fieldWithPath("data[].createDate").type(STRING).description("회고 등록 날짜"),
+					fieldWithPath("data[].endUpdateDate").type(STRING).description("회고 수정 마감 날짜")
 				)));
 	}
 
@@ -184,7 +186,8 @@ public class DiaryControllerTest {
 					fieldWithPath("message").type(STRING).description("결과 메시지"),
 					fieldWithPath("data[].id").type(NUMBER).description("회고록 아이디"),
 					fieldWithPath("data[].content").type(STRING).description("회고록 내용"),
-					fieldWithPath("data[].createDate").type(STRING).description("회고 등록 날짜")
+					fieldWithPath("data[].createDate").type(STRING).description("회고 등록 날짜"),
+					fieldWithPath("data[].endUpdateDate").type(STRING).description("회고 수정 마감 날짜")
 				)));
 	}
 


### PR DESCRIPTION
## 작업 사항
회고록 조회,수정 시 마감 날짜를 포함하여 반환 하도록 수정하였습니다.

[chore(dto) : DiaryResponse 필드 추가](https://github.com/potenday-project/Habiters_BE/commit/17aa23f4525fa4d8ab627b8403b4cd1ea76cbcd1) 
- 마감 날짜를 포함하여 반환하도록 수정하였습니다.
 
[chore(Test_Diary) : DiaryControllerTest RestDocs 수정](https://github.com/potenday-project/Habiters_BE/commit/1d7a419fd9aa21f1b7d7cc3d70848a60fca57a57) 
- 회고록 반환 필드에 마감 날짜가 추가되어, 해당 내용을 추가하였습니다.